### PR TITLE
Enhancement/locale

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,8 +7,11 @@ export default function useIntlDates({ locale = "default" } = {}) {
     month: "numeric",
     year: "numeric",
   });
-  const [intlMonthLongOptions] = useState({ month: "long" });
-  const [intlMWShortOptions] = useState({
+  const [intlMonthWeekdayLongOptions] = useState({
+    month: "long",
+    weekday: "long",
+  });
+  const [intlMonthWeekdayShortOptions] = useState({
     month: "short",
     weekday: "short",
   });
@@ -108,7 +111,6 @@ export default function useIntlDates({ locale = "default" } = {}) {
       setdateDMY(dateDMYString);
       setdateMDY(dateMDYString);
       setWeekdayLong(startValues[0].value);
-      setDayOfMonth(startValues[4].value);
       setMonthNumeric(startValues[2].value);
       setYear(startValues[6].value);
     }
@@ -118,24 +120,25 @@ export default function useIntlDates({ locale = "default" } = {}) {
   useEffect(() => {
     const formatter = new Intl.DateTimeFormat(
       !!locale ? locale : "default",
-      intlMonthLongOptions
+      intlMonthWeekdayLongOptions
     );
     const formatted = formatter.formatToParts(new Date());
 
     setMonthLong(formatted[0].value);
-  }, [intlMonthLongOptions, locale]);
+    setWeekdayLong(formatted[2].value);
+  }, [intlMonthWeekdayLongOptions, locale]);
 
   // Set monthShort and weekdayShort values
   useEffect(() => {
     const formatter = new Intl.DateTimeFormat(
       !!locale ? locale : "default",
-      intlMWShortOptions
+      intlMonthWeekdayShortOptions
     );
     const formatted = formatter.formatToParts(new Date());
 
     setMonthShort(formatted[0].value);
     setWeekdayShort(formatted[2].value);
-  }, [intlMWShortOptions, locale]);
+  }, [intlMonthWeekdayShortOptions, locale]);
 
   let dates = {
     weekStartDate,

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 
-export default function useIntlDates({ locale }) {
+export default function useIntlDates({ locale = "default" } = {}) {
   const [intlBaseOptions] = useState({
     weekday: "long",
     day: "numeric",
@@ -76,12 +76,9 @@ export default function useIntlDates({ locale }) {
 
   // Set startValues with Intl
   useEffect(() => {
-    const formatter = new Intl.DateTimeFormat(
-      !!locale ? locale : "default",
-      intlBaseOptions
-    );
+    const formatter = new Intl.DateTimeFormat("en-US", intlBaseOptions);
     setStartValues(formatter.formatToParts(new Date()));
-  }, [intlBaseOptions, locale]);
+  }, [intlBaseOptions]);
 
   // Derive this week start and end dates and set in state
   useEffect(() => {

--- a/index.js
+++ b/index.js
@@ -101,15 +101,15 @@ export default function useIntlDates({ locale = "default" } = {}) {
   // Set additional values to export
   useEffect(() => {
     if (startValues) {
-      let dateYMDString = `${startValues[6].value}-${startValues[2].value}-${startValues[4].value}`;
+      let dateYMD = `${startValues[6].value}-${startValues[2].value}-${startValues[4].value}`;
 
-      let dateDMYString = `${startValues[4].value}-${startValues[2].value}-${startValues[6].value}`;
+      let dateDMY = `${startValues[4].value}-${startValues[2].value}-${startValues[6].value}`;
 
-      let dateMDYString = `${startValues[2].value}-${startValues[4].value}-${startValues[6].value}`;
+      let dateMDY = `${startValues[2].value}-${startValues[4].value}-${startValues[6].value}`;
 
-      setdateYMD(dateYMDString);
-      setdateDMY(dateDMYString);
-      setdateMDY(dateMDYString);
+      setdateYMD(dateYMD);
+      setdateDMY(dateDMY);
+      setdateMDY(dateMDY);
       setWeekdayLong(startValues[0].value);
       setMonthNumeric(startValues[2].value);
       setYear(startValues[6].value);
@@ -119,7 +119,7 @@ export default function useIntlDates({ locale = "default" } = {}) {
   // Set monthLong weekdayLong values
   useEffect(() => {
     const formatter = new Intl.DateTimeFormat(
-      !!locale ? locale : "default",
+      locale,
       intlMonthWeekdayLongOptions
     );
     const formatted = formatter.formatToParts(new Date());
@@ -131,7 +131,7 @@ export default function useIntlDates({ locale = "default" } = {}) {
   // Set monthShort and weekdayShort values
   useEffect(() => {
     const formatter = new Intl.DateTimeFormat(
-      !!locale ? locale : "default",
+      locale,
       intlMonthWeekdayShortOptions
     );
     const formatted = formatter.formatToParts(new Date());


### PR DESCRIPTION
This PR introduces the ability to pass an option object to the `useIntlDates` hook that specifies a locale.
Also included are small logic and naming improvements.