### PR TITLE
Feature/vanilla convert

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
 import useIntlDates from "./hook";
+import intlDates from "./vanilla";
 
-export default useIntlDates;
+export { useIntlDates as default, intlDates };

--- a/vanilla/index.js
+++ b/vanilla/index.js
@@ -96,20 +96,20 @@ export default function useIntlDates({ locale = "default" } = {}) {
   dateMDY = `${startValues[2].value}-${startValues[4].value}-${startValues[6].value}`;
 
   monthNumeric = startValues[2].value;
+
   dayOfMonth = startValues[4].value;
+
   year = startValues[6].value;
 
   // Set monthLong weekdayLong values
-  useEffect(() => {
-    const formatter = new Intl.DateTimeFormat(
-      locale,
-      intlMonthWeekdayLongOptions
-    );
-    const formatted = formatter.formatToParts(new Date());
+  const longFormatter = new Intl.DateTimeFormat(
+    locale,
+    intlMonthWeekdayLongOptions
+  );
+  const longFormatted = longFormatter.formatToParts(new Date());
 
-    setMonthLong(formatted[0].value);
-    setWeekdayLong(formatted[2].value);
-  }, [intlMonthWeekdayLongOptions, locale]);
+  monthLong = longFormatted[0].value;
+  weekdayLong = longFormatted[2].value;
 
   // Set monthShort and weekdayShort values
   useEffect(() => {

--- a/vanilla/index.js
+++ b/vanilla/index.js
@@ -89,22 +89,15 @@ export default function useIntlDates({ locale = "default" } = {}) {
   }-${findEndOfWeek(startValues)}`;
 
   // Set additional values to export
-  useEffect(() => {
-    if (startValues) {
-      let dateYMD = `${startValues[6].value}-${startValues[2].value}-${startValues[4].value}`;
+  dateYMD = `${startValues[6].value}-${startValues[2].value}-${startValues[4].value}`;
 
-      let dateDMY = `${startValues[4].value}-${startValues[2].value}-${startValues[6].value}`;
+  dateDMY = `${startValues[4].value}-${startValues[2].value}-${startValues[6].value}`;
 
-      let dateMDY = `${startValues[2].value}-${startValues[4].value}-${startValues[6].value}`;
+  dateMDY = `${startValues[2].value}-${startValues[4].value}-${startValues[6].value}`;
 
-      setdateYMD(dateYMD);
-      setdateDMY(dateDMY);
-      setdateMDY(dateMDY);
-      setMonthNumeric(startValues[2].value);
-      setDayOfMonth(startValues[4].value);
-      setYear(startValues[6].value);
-    }
-  }, [startValues]);
+  monthNumeric = startValues[2].value;
+  dayOfMonth = startValues[4].value;
+  year = startValues[6].value;
 
   // Set monthLong weekdayLong values
   useEffect(() => {

--- a/vanilla/index.js
+++ b/vanilla/index.js
@@ -1,31 +1,21 @@
 export default function useIntlDates({ locale = "default" } = {}) {
-  const [intlBaseOptions] = {
+  // Set options passed to Intl calls
+  const intlBaseOptions = {
     weekday: "long",
     day: "numeric",
     month: "numeric",
     year: "numeric",
   };
-  const [intlMonthWeekdayLongOptions] = {
+
+  const intlMonthWeekdayLongOptions = {
     month: "long",
     weekday: "long",
   };
-  const [intlMonthWeekdayShortOptions] = {
+
+  const intlMonthWeekdayShortOptions = {
     month: "short",
     weekday: "short",
   };
-  let startValues;
-  let weekStartDate;
-  let weekEndDate;
-  let dateYMD;
-  let dateDMY;
-  let dateMDY;
-  let weekdayLong;
-  let weekdayShort;
-  let dayOfMonth;
-  let monthNumeric;
-  let monthLong;
-  let monthShort;
-  let year;
 
   const findStartOfWeek = (intlValues) => {
     const weekday = intlValues[0].value;
@@ -80,26 +70,26 @@ export default function useIntlDates({ locale = "default" } = {}) {
   startValues = baseFormatter.formatToParts(new Date());
 
   // Derive this week start and end dates and set to variables
-  weekStartDate = `${startValues[6].value}-${
+  const weekStartDate = `${startValues[6].value}-${
     startValues[2].value
   }-${findStartOfWeek(startValues)}`;
 
-  weekEndDate = `${startValues[6].value}-${
+  const weekEndDate = `${startValues[6].value}-${
     startValues[2].value
   }-${findEndOfWeek(startValues)}`;
 
   // Set additional values to export
-  dateYMD = `${startValues[6].value}-${startValues[2].value}-${startValues[4].value}`;
+  const dateYMD = `${startValues[6].value}-${startValues[2].value}-${startValues[4].value}`;
 
-  dateDMY = `${startValues[4].value}-${startValues[2].value}-${startValues[6].value}`;
+  const dateDMY = `${startValues[4].value}-${startValues[2].value}-${startValues[6].value}`;
 
-  dateMDY = `${startValues[2].value}-${startValues[4].value}-${startValues[6].value}`;
+  const dateMDY = `${startValues[2].value}-${startValues[4].value}-${startValues[6].value}`;
 
-  monthNumeric = startValues[2].value;
+  const monthNumeric = startValues[2].value;
 
-  dayOfMonth = startValues[4].value;
+  const dayOfMonth = startValues[4].value;
 
-  year = startValues[6].value;
+  const year = startValues[6].value;
 
   // Set monthLong weekdayLong values
   const longFormatter = new Intl.DateTimeFormat(
@@ -108,22 +98,20 @@ export default function useIntlDates({ locale = "default" } = {}) {
   );
   const longFormatted = longFormatter.formatToParts(new Date());
 
-  monthLong = longFormatted[0].value;
-  weekdayLong = longFormatted[2].value;
+  const monthLong = longFormatted[0].value;
+  const weekdayLong = longFormatted[2].value;
 
   // Set monthShort and weekdayShort values
-  useEffect(() => {
-    const formatter = new Intl.DateTimeFormat(
-      locale,
-      intlMonthWeekdayShortOptions
-    );
-    const formatted = formatter.formatToParts(new Date());
+  const shortFormatter = new Intl.DateTimeFormat(
+    locale,
+    intlMonthWeekdayShortOptions
+  );
+  const shortFormatted = shortFormatter.formatToParts(new Date());
 
-    setMonthShort(formatted[0].value);
-    setWeekdayShort(formatted[2].value);
-  }, [intlMonthWeekdayShortOptions, locale]);
+  const monthShort = shortFormatted[0].value;
+  const weekdayShort = shortFormatted[2].value;
 
-  let dates = {
+  const dates = {
     weekStartDate,
     weekEndDate,
     dateYMD,

--- a/vanilla/index.js
+++ b/vanilla/index.js
@@ -76,25 +76,17 @@ export default function useIntlDates({ locale = "default" } = {}) {
   };
 
   // Set startValues with Intl
-  useEffect(() => {
-    const formatter = new Intl.DateTimeFormat("en-US", intlBaseOptions);
-    setStartValues(formatter.formatToParts(new Date()));
-  }, [intlBaseOptions]);
+  const baseFormatter = new Intl.DateTimeFormat("en-US", intlBaseOptions);
+  startValues = baseFormatter.formatToParts(new Date());
 
-  // Derive this week start and end dates and set in state
-  useEffect(() => {
-    if (startValues) {
-      let sundayDate = `${startValues[6].value}-${
-        startValues[2].value
-      }-${findStartOfWeek(startValues)}`;
-      let saturdayDate = `${startValues[6].value}-${
-        startValues[2].value
-      }-${findEndOfWeek(startValues)}`;
+  // Derive this week start and end dates and set to variables
+  weekStartDate = `${startValues[6].value}-${
+    startValues[2].value
+  }-${findStartOfWeek(startValues)}`;
 
-      setWeekStartDate(sundayDate);
-      setWeekEndDate(saturdayDate);
-    }
-  }, [startValues]);
+  weekEndDate = `${startValues[6].value}-${
+    startValues[2].value
+  }-${findEndOfWeek(startValues)}`;
 
   // Set additional values to export
   useEffect(() => {

--- a/vanilla/index.js
+++ b/vanilla/index.js
@@ -1,4 +1,4 @@
-export default function useIntlDates({ locale = "default" } = {}) {
+export default function intlDates({ locale = "default" } = {}) {
   // Set options passed to Intl calls
   const intlBaseOptions = {
     weekday: "long",
@@ -67,7 +67,7 @@ export default function useIntlDates({ locale = "default" } = {}) {
 
   // Set startValues with Intl
   const baseFormatter = new Intl.DateTimeFormat("en-US", intlBaseOptions);
-  startValues = baseFormatter.formatToParts(new Date());
+  const startValues = baseFormatter.formatToParts(new Date());
 
   // Derive this week start and end dates and set to variables
   const weekStartDate = `${startValues[6].value}-${

--- a/vanilla/index.js
+++ b/vanilla/index.js
@@ -1,0 +1,157 @@
+export default function useIntlDates({ locale = "default" } = {}) {
+  const [intlBaseOptions] = {
+    weekday: "long",
+    day: "numeric",
+    month: "numeric",
+    year: "numeric",
+  };
+  const [intlMonthWeekdayLongOptions] = {
+    month: "long",
+    weekday: "long",
+  };
+  const [intlMonthWeekdayShortOptions] = {
+    month: "short",
+    weekday: "short",
+  };
+  let startValues;
+  let weekStartDate;
+  let weekEndDate;
+  let dateYMD;
+  let dateDMY;
+  let dateMDY;
+  let weekdayLong;
+  let weekdayShort;
+  let dayOfMonth;
+  let monthNumeric;
+  let monthLong;
+  let monthShort;
+  let year;
+
+  const findStartOfWeek = (intlValues) => {
+    const weekday = intlValues[0].value;
+    const dayOfMonth = intlValues[4].value;
+
+    switch (weekday) {
+      case "Sunday":
+        return Number(dayOfMonth);
+      case "Monday":
+        return Number(dayOfMonth) - 1;
+      case "Tuesday":
+        return Number(dayOfMonth) - 2;
+      case "Wednesday":
+        return Number(dayOfMonth) - 3;
+      case "Thursday":
+        return Number(dayOfMonth) - 4;
+      case "Friday":
+        return Number(dayOfMonth) - 5;
+      case "Saturday":
+        return Number(dayOfMonth) - 6;
+      default:
+        return null;
+    }
+  };
+
+  const findEndOfWeek = (intlValues) => {
+    const weekday = intlValues[0].value;
+    const dayOfMonth = intlValues[4].value;
+
+    switch (weekday) {
+      case "Sunday":
+        return Number(dayOfMonth) + 6;
+      case "Monday":
+        return Number(dayOfMonth) + 5;
+      case "Tuesday":
+        return Number(dayOfMonth) + 4;
+      case "Wednesday":
+        return Number(dayOfMonth) + 3;
+      case "Thursday":
+        return Number(dayOfMonth) + 2;
+      case "Friday":
+        return Number(dayOfMonth) + 1;
+      case "Saturday":
+        return Number(dayOfMonth);
+      default:
+        return null;
+    }
+  };
+
+  // Set startValues with Intl
+  useEffect(() => {
+    const formatter = new Intl.DateTimeFormat("en-US", intlBaseOptions);
+    setStartValues(formatter.formatToParts(new Date()));
+  }, [intlBaseOptions]);
+
+  // Derive this week start and end dates and set in state
+  useEffect(() => {
+    if (startValues) {
+      let sundayDate = `${startValues[6].value}-${
+        startValues[2].value
+      }-${findStartOfWeek(startValues)}`;
+      let saturdayDate = `${startValues[6].value}-${
+        startValues[2].value
+      }-${findEndOfWeek(startValues)}`;
+
+      setWeekStartDate(sundayDate);
+      setWeekEndDate(saturdayDate);
+    }
+  }, [startValues]);
+
+  // Set additional values to export
+  useEffect(() => {
+    if (startValues) {
+      let dateYMD = `${startValues[6].value}-${startValues[2].value}-${startValues[4].value}`;
+
+      let dateDMY = `${startValues[4].value}-${startValues[2].value}-${startValues[6].value}`;
+
+      let dateMDY = `${startValues[2].value}-${startValues[4].value}-${startValues[6].value}`;
+
+      setdateYMD(dateYMD);
+      setdateDMY(dateDMY);
+      setdateMDY(dateMDY);
+      setMonthNumeric(startValues[2].value);
+      setDayOfMonth(startValues[4].value);
+      setYear(startValues[6].value);
+    }
+  }, [startValues]);
+
+  // Set monthLong weekdayLong values
+  useEffect(() => {
+    const formatter = new Intl.DateTimeFormat(
+      locale,
+      intlMonthWeekdayLongOptions
+    );
+    const formatted = formatter.formatToParts(new Date());
+
+    setMonthLong(formatted[0].value);
+    setWeekdayLong(formatted[2].value);
+  }, [intlMonthWeekdayLongOptions, locale]);
+
+  // Set monthShort and weekdayShort values
+  useEffect(() => {
+    const formatter = new Intl.DateTimeFormat(
+      locale,
+      intlMonthWeekdayShortOptions
+    );
+    const formatted = formatter.formatToParts(new Date());
+
+    setMonthShort(formatted[0].value);
+    setWeekdayShort(formatted[2].value);
+  }, [intlMonthWeekdayShortOptions, locale]);
+
+  let dates = {
+    weekStartDate,
+    weekEndDate,
+    dateYMD,
+    dateDMY,
+    dateMDY,
+    weekdayLong,
+    weekdayShort,
+    dayOfMonth,
+    monthNumeric,
+    monthLong,
+    monthShort,
+    year,
+  };
+
+  return dates;
+}


### PR DESCRIPTION
This PR accomplishes:
- Moving the custom React Hook version to its own directory/file
- Make a VanillaJS version of the package and export as `intlDates` function
- Export the custom Hook as default and `intlDates` as a named function export from the main `index.js` (done this way so it does not break existing usage of the custom Hook, which was the default export from the start)

This has been tested locally, but should be verified after docs are done.

Closes #9 #10 