### PR TITLE
Bug/dates

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ export default function useIntlDates({ locale = "default" } = {}) {
   const [monthLong, setMonthLong] = useState();
   const [monthShort, setMonthShort] = useState();
   const [year, setYear] = useState();
+  const [dates, setDates] = useState({});
 
   const findStartOfWeek = (intlValues) => {
     const weekday = intlValues[0].value;
@@ -140,7 +141,24 @@ export default function useIntlDates({ locale = "default" } = {}) {
     setWeekdayShort(formatted[2].value);
   }, [intlMonthWeekdayShortOptions, locale]);
 
-  let dates = {
+  // Set all in state
+  useEffect(() => {
+    setDates({
+      weekStartDate,
+      weekEndDate,
+      dateYMD,
+      dateDMY,
+      dateMDY,
+      weekdayLong,
+      weekdayShort,
+      dayOfMonth,
+      monthNumeric,
+      monthLong,
+      monthShort,
+      year,
+    });
+  }, [
+    setDates,
     weekStartDate,
     weekEndDate,
     dateYMD,
@@ -153,7 +171,7 @@ export default function useIntlDates({ locale = "default" } = {}) {
     monthLong,
     monthShort,
     year,
-  };
+  ]);
 
   return dates;
 }

--- a/index.js
+++ b/index.js
@@ -83,10 +83,11 @@ export default function useIntlDates({ locale = "default" } = {}) {
       }-${findEndOfWeek(startValues)}`;
 
       setDates((dates) => {
-        return { ...dates, weekStartDate: sundayDate };
-      });
-      setDates((dates) => {
-        return { ...dates, weekEndDate: saturdayDate };
+        return {
+          ...dates,
+          weekStartDate: sundayDate,
+          weekEndDate: saturdayDate,
+        };
       });
     }
   }, [startValues]);
@@ -101,22 +102,15 @@ export default function useIntlDates({ locale = "default" } = {}) {
       let dateMDY = `${startValues[2].value}-${startValues[4].value}-${startValues[6].value}`;
 
       setDates((dates) => {
-        return { ...dates, dateYMD };
-      });
-      setDates((dates) => {
-        return { ...dates, dateDMY };
-      });
-      setDates((dates) => {
-        return { ...dates, dateMDY };
-      });
-      setDates((dates) => {
-        return { ...dates, monthNumeric: startValues[2].value };
-      });
-      setDates((dates) => {
-        return { ...dates, dayOfMonth: startValues[4].value };
-      });
-      setDates((dates) => {
-        return { ...dates, year: startValues[6].value };
+        return {
+          ...dates,
+          dateYMD,
+          dateDMY,
+          dateMDY,
+          monthNumeric: startValues[2].value,
+          dayOfMonth: startValues[4].value,
+          year: startValues[6].value,
+        };
       });
     }
   }, [startValues]);
@@ -130,10 +124,11 @@ export default function useIntlDates({ locale = "default" } = {}) {
     const formatted = formatter.formatToParts(new Date());
 
     setDates((dates) => {
-      return { ...dates, monthLong: formatted[0].value };
-    });
-    setDates((dates) => {
-      return { ...dates, weekdayLong: formatted[2].value };
+      return {
+        ...dates,
+        monthLong: formatted[0].value,
+        weekdayLong: formatted[2].value,
+      };
     });
   }, [intlMonthWeekdayLongOptions, locale]);
 
@@ -146,10 +141,11 @@ export default function useIntlDates({ locale = "default" } = {}) {
     const formatted = formatter.formatToParts(new Date());
 
     setDates((dates) => {
-      return { ...dates, monthShort: formatted[0].value };
-    });
-    setDates((dates) => {
-      return { ...dates, weekdayShort: formatted[2].value };
+      return {
+        ...dates,
+        monthShort: formatted[0].value,
+        weekdayShort: formatted[2].value,
+      };
     });
   }, [intlMonthWeekdayShortOptions, locale]);
 

--- a/index.js
+++ b/index.js
@@ -16,18 +16,6 @@ export default function useIntlDates({ locale = "default" } = {}) {
     weekday: "short",
   });
   const [startValues, setStartValues] = useState();
-  const [weekStartDate, setWeekStartDate] = useState();
-  const [weekEndDate, setWeekEndDate] = useState();
-  const [dateYMD, setdateYMD] = useState();
-  const [dateDMY, setdateDMY] = useState();
-  const [dateMDY, setdateMDY] = useState();
-  const [weekdayLong, setWeekdayLong] = useState();
-  const [weekdayShort, setWeekdayShort] = useState();
-  const [dayOfMonth, setDayOfMonth] = useState();
-  const [monthNumeric, setMonthNumeric] = useState();
-  const [monthLong, setMonthLong] = useState();
-  const [monthShort, setMonthShort] = useState();
-  const [year, setYear] = useState();
   const [dates, setDates] = useState({});
 
   const findStartOfWeek = (intlValues) => {
@@ -94,8 +82,12 @@ export default function useIntlDates({ locale = "default" } = {}) {
         startValues[2].value
       }-${findEndOfWeek(startValues)}`;
 
-      setWeekStartDate(sundayDate);
-      setWeekEndDate(saturdayDate);
+      setDates((dates) => {
+        return { ...dates, weekStartDate: sundayDate };
+      });
+      setDates((dates) => {
+        return { ...dates, weekEndDate: saturdayDate };
+      });
     }
   }, [startValues]);
 
@@ -108,12 +100,24 @@ export default function useIntlDates({ locale = "default" } = {}) {
 
       let dateMDY = `${startValues[2].value}-${startValues[4].value}-${startValues[6].value}`;
 
-      setdateYMD(dateYMD);
-      setdateDMY(dateDMY);
-      setdateMDY(dateMDY);
-      setMonthNumeric(startValues[2].value);
-      setDayOfMonth(startValues[4].value);
-      setYear(startValues[6].value);
+      setDates((dates) => {
+        return { ...dates, dateYMD };
+      });
+      setDates((dates) => {
+        return { ...dates, dateDMY };
+      });
+      setDates((dates) => {
+        return { ...dates, dateMDY };
+      });
+      setDates((dates) => {
+        return { ...dates, monthNumeric: startValues[2].value };
+      });
+      setDates((dates) => {
+        return { ...dates, dayOfMonth: startValues[4].value };
+      });
+      setDates((dates) => {
+        return { ...dates, year: startValues[6].value };
+      });
     }
   }, [startValues]);
 
@@ -125,8 +129,12 @@ export default function useIntlDates({ locale = "default" } = {}) {
     );
     const formatted = formatter.formatToParts(new Date());
 
-    setMonthLong(formatted[0].value);
-    setWeekdayLong(formatted[2].value);
+    setDates((dates) => {
+      return { ...dates, monthLong: formatted[0].value };
+    });
+    setDates((dates) => {
+      return { ...dates, weekdayLong: formatted[2].value };
+    });
   }, [intlMonthWeekdayLongOptions, locale]);
 
   // Set monthShort and weekdayShort values
@@ -137,41 +145,13 @@ export default function useIntlDates({ locale = "default" } = {}) {
     );
     const formatted = formatter.formatToParts(new Date());
 
-    setMonthShort(formatted[0].value);
-    setWeekdayShort(formatted[2].value);
-  }, [intlMonthWeekdayShortOptions, locale]);
-
-  // Set all in state
-  useEffect(() => {
-    setDates({
-      weekStartDate,
-      weekEndDate,
-      dateYMD,
-      dateDMY,
-      dateMDY,
-      weekdayLong,
-      weekdayShort,
-      dayOfMonth,
-      monthNumeric,
-      monthLong,
-      monthShort,
-      year,
+    setDates((dates) => {
+      return { ...dates, monthShort: formatted[0].value };
     });
-  }, [
-    setDates,
-    weekStartDate,
-    weekEndDate,
-    dateYMD,
-    dateDMY,
-    dateMDY,
-    weekdayLong,
-    weekdayShort,
-    dayOfMonth,
-    monthNumeric,
-    monthLong,
-    monthShort,
-    year,
-  ]);
+    setDates((dates) => {
+      return { ...dates, weekdayShort: formatted[2].value };
+    });
+  }, [intlMonthWeekdayShortOptions, locale]);
 
   return dates;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "useintldates",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Easily work with dates using the JavaScript Intl methods",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR fixes the issue with `dates` being a static variable instead of controlled state. These things were changed:

1. Moved `dates` to an object in state.
2. Set propertied needed in `dates` object with `setDates` update method provided by `useState`
3. Refactored code to remove having every property saved in state individually, instead the properties are added through the update method directly into the `dates` object
4. Bumped version to 1.0.3 to reflect bug patch in publish

fixes #15 