### PR TITLE
Feature/option date

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# useIntlDates
+# intl-dates
+
+Easily get useful date-related information using JavaScript Intl.
+
+### Description
 
 This package provides a quick and easy way to work with dates by returning an object containing commonly used, helpful date-related data. It can also be passed an [options object](#options) to further customize the way the date information comes back, such as language (locale). <br />
 
@@ -63,17 +67,20 @@ Great news! This code uses the power of the [JavaScript Intl object](https://dev
 
 Both `intlDates` and `useIntlDates` will accept an object of these options ([see usage below](#specify-locale)):
 
-1. `locale` [_optional_]<br />
+1. `locale` [_optional_]
 
    - default: "default" &nbsp; [_defaults to the locale identified by the browser_]<br />
    - This option allows you to get date information back in a specific language. <br />
    - Any valid locale acceptable to [Intl](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#locales_argument) will work.<br />
    - Examples: "en-US", "da-DK", "de", "es"
 
-2. `date` [_optional_] <br />
+<br />
+
+2. `date` [_optional_]
+
    - default: today's date <br />
    - This option allows you to get back date information based on a specific date. <br />
-   - Any value accepted by the [JavaScript `Date()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date#Parameters) constructor will work. <br />
+   - Any value accepted by the JavaScript [Date()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date#Parameters) constructor will work. <br />
    - Examples: "2020-10-24T14:48:00", "2020-10-24", "10/24/2020", "October 24, 2020"
 
 ## Examples
@@ -82,15 +89,15 @@ The only difference in usage between `intlDates` and `useIntlDates` is the conte
 
 #### Common Use
 
-Get date-related info and format it as you need. Consider the following if it were _Saturday, October 24, 2020_.<br />
+Get date-related info and format it as you need. Consider the following if today was _Saturday, October 24, 2020_.<br />
 
 ###### Using `intlDates` function
 
 ```
 import { intlDates } from 'useintldates'; // Bring the function into your code as a named export
 
-const dates = intlDates();
 // Retrieve and destructure the 'dates' object from the intlDates function
+const dates = intlDates();
 
 ...
 
@@ -110,8 +117,9 @@ const dates = intlDates();
 import useIntlDates from 'useintldates'; // Bring the hook into your component
 
 const MyComponent = () => {
-  const dates = useIntlDates();
+
   // Retrieve and destructure the 'dates' object from the useIntlDates hook
+  const dates = useIntlDates();
 
   return(
     <div>
@@ -135,10 +143,10 @@ Return date information based on a specific date. Consider if you wanted to get 
 ```
 import { intlDates } from 'useintldates'; // Bring the function into your code as a named export
 
-const dates = intlDates({
-  date: "2/15/1999", // Specify a date in options object
-  });
 // Retrieve and destructure the 'dates' object from the intlDates function
+const dates = intlDates({
+  date: "2/15/1999"  // Specify a date in options object
+  });
 
 ...
 
@@ -158,10 +166,11 @@ const dates = intlDates({
 import useIntlDates from 'useintldates'; // Bring the hook into your component
 
 const MyComponent = () => {
-  const dates = useIntlDates({
-    date: "2/15/1999", // Specify a date in options object
-    });
+
   // Retrieve and destructure the 'dates' object from the useIntlDates hook
+  const dates = useIntlDates({
+    date: "2/15/1999"  // Specify a date in options object
+    });
 
   return(
     <div>
@@ -187,12 +196,10 @@ Passing in a specific locale through the options object will return the data in 
 ```
 import { intlDates } from 'useintldates'; // Bring the function into your code as a named export
 
-
-const dates = intlDates({
-  locale: "da-DK"
-  // Set the locale to return in Danish
-});
 // Retrieve and destructure the 'dates' object from the intlDates function
+const dates = intlDates({
+  locale: "da-DK"  // Set the locale to return in Danish
+});
 
 ...
 
@@ -212,11 +219,11 @@ const dates = intlDates({
 import useIntlDates from 'useintldates'; // Bring the hook into your component
 
 const MyComponent = () => {
-  const dates = useIntlDates({
-    locale: "da-DK"
-    // Set the locale to return in Danish
-  });
+
   // Retrieve and destructure the 'dates' object from the useIntlDates hook
+  const dates = useIntlDates({
+    locale: "da-DK"  // Set the locale to return in Danish
+  });
 
   return(
     <div>
@@ -233,16 +240,18 @@ const MyComponent = () => {
 
 #### Date Ranges
 
-Say you need the date for the first and last day of the week (Sunday and Saturday) to request a range of data from an API for the _current_ week. <br /> <br />
-The following would make the request with the date of Sunday in the current week coming from `dates.weekStartDate` and the date for Saturday from `dates.weekEndDate` in the format 'YYYY-MM-DD' <br />
+Say you need the date for the first and last day of the week (Sunday and Saturday) to request a range of data from an API for the week. <br /> <br />
+The following would make the request with the date for Sunday coming from `dates.weekStartDate` and the date for Saturday from `dates.weekEndDate` in the format 'YYYY-MM-DD': <br />
+
+> Note: Dates are based on the _current_ week if no date is passed as an option, else the dates are based on the week in which the specified date falls.
 
 ###### Using `intlDates` function
 
 ```
 import { intlDates } from 'useintldates'; // Bring the function into your code as a named export
 
+// Retrieve and destructure the 'dates' object from the intlDates function
 const dates = intlDates();
-  // Retrieve and destructure the 'dates' object from the intlDates function
 
 fetch(`[urlToYourAPI]/getByDateRange?startDate=${dates.weekStartDate}&endDate=${dates.weekEndDate}`)
 
@@ -258,8 +267,9 @@ fetch(`[urlToYourAPI]/getByDateRange?startDate=${dates.weekStartDate}&endDate=${
     import useIntlDates from 'useintldates'; // Bring the hook into your component
 
     const MyComponent = () => {
+
+      // Retrieve and destructure the 'dates' object from the useIntlDates hook
       const dates = useIntlDates();
-        // Retrieve and destructure the 'dates' object from the useIntlDates hook
 
       useEffect(() => {
         fetch(`[urlToYourAPI]/getByDateRange?startDate=${dates.weekStartDate}&endDate=${dates.weekEndDate}`)
@@ -279,9 +289,9 @@ fetch(`[urlToYourAPI]/getByDateRange?startDate=${dates.weekStartDate}&endDate=${
 This list includes current and planned features. Check the issues page for a more exhaustive look at what features are being added and where they stand in the development process.
 
 - [x] No dependencies, simply JavaScript code
-- [x] This package has a VanillaJS option
-- [x] Options object accepts locale property to specify a locale/language for Intl to use
-- [ ] Options object will allow a 'date' property to get back data based on a specific date instead of only from the current day.
+- [x] This package offers a VanillaJS and custom React hook option
+- [x] Options object accepts `locale` property to specify a locale/language for Intl to use
+- [x] Options object will allow a `date` property to get back data based on a specific date instead of only from the current day.
 
 ## Why offer VanillaJS and hook options?
 

--- a/README.md
+++ b/README.md
@@ -64,9 +64,17 @@ Great news! This code uses the power of the [JavaScript Intl object](https://dev
 Both `intlDates` and `useIntlDates` will accept an object of these options ([see usage below](#specify-locale)):
 
 1. `locale` [_optional_]<br />
+
    - default: "default" &nbsp; [_defaults to the locale identified by the browser_]<br />
-   - This option allows you to pass a specific locale in the call to the Intl constructor. Any valid [locale acceptable to Intl](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#locales_argument) will work.<br />
+   - This option allows you to get date information back in a specific language. <br />
+   - Any valid locale acceptable to [Intl](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#locales_argument) will work.<br />
    - Examples: "en-US", "da-DK", "de", "es"
+
+2. `date` [_optional_] <br />
+   - default: today's date <br />
+   - This option allows you to get back date information based on a specific date. <br />
+   - Any value accepted by the [JavaScript `Date()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date#Parameters) constructor will work. <br />
+   - Examples: "2020-10-24T14:48:00", "2020-10-24", "10/24/2020", "October 24, 2020"
 
 ## Examples
 
@@ -74,7 +82,7 @@ The only difference in usage between `intlDates` and `useIntlDates` is the conte
 
 #### Common Use
 
-Get date-related info and format it as you need. The date information is based on the current day. Consider the following if it were _Saturday, October 24, 2020_.<br />
+Get date-related info and format it as you need. Consider the following if it were _Saturday, October 24, 2020_.<br />
 
 ###### Using `intlDates` function
 
@@ -113,6 +121,56 @@ const MyComponent = () => {
 }
 
 // Would return "Today is Saturday, Oct 24, 2020"
+
+```
+
+<br />
+
+#### Specify Date
+
+Return date information based on a specific date. Consider if you wanted to get information based on _Monday, February 15, 1999_.<br />
+
+###### Using `intlDates` function
+
+```
+import { intlDates } from 'useintldates'; // Bring the function into your code as a named export
+
+const dates = intlDates({
+  date: "2/15/1999", // Specify a date in options object
+  });
+// Retrieve and destructure the 'dates' object from the intlDates function
+
+...
+
+  <div>
+  `Today is ${dates.weekdayLong} ${dates.monthShort} ${dates.dayOfMonth}, ${dates.year}`
+  </div>
+
+...
+
+// Would result in "Today is Monday, Feb 15, 1999"
+
+```
+
+###### Using `useIntlDates` custom hook
+
+```
+import useIntlDates from 'useintldates'; // Bring the hook into your component
+
+const MyComponent = () => {
+  const dates = useIntlDates({
+    date: "2/15/1999", // Specify a date in options object
+    });
+  // Retrieve and destructure the 'dates' object from the useIntlDates hook
+
+  return(
+    <div>
+    `Today is ${dates.weekdayLong} ${dates.monthShort} ${dates.dayOfMonth}, ${dates.year}`
+    </div>
+  )
+}
+
+// Would return "Today is Monday, Feb 15, 1999"
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Easily get useful date-related information using JavaScript Intl.
 
 ### Description
 
-This package provides a quick and easy way to work with dates by returning an object containing commonly used, helpful date-related data. It can also be passed an [options object](#options) to further customize the way the date information comes back, such as language (locale). <br />
+This package provides a quick and easy way to work with dates by returning an object containing commonly used, date-related data. It can also be passed an [options object](#options) to further customize the way the date information comes back. <br />
 
-For your convenience, this package exports both a Vanilla JavaScript function (`intlDates`) and a custom React hook (`useIntlDates`). Both return the same object (`dates`) containing helpful date-related data.
+This package exports both a Vanilla JavaScript function (`intlDates`) and a custom React hook (`useIntlDates`), each of which return an object (`dates`) containing the same key/value pairs.
 
 ### Sections:
 
@@ -20,7 +20,7 @@ For your convenience, this package exports both a Vanilla JavaScript function (`
 
 ## Installation
 
-- This npm package can be installed by running `npm install useintldates --save-dev`
+- This npm package can be installed by running `npm install intl-dates --save-dev`
 - See [Date Information](#date-information) for more info on what data is returned
 - See [Examples](#examples) further down to see how the package would be brought into your project
 
@@ -94,7 +94,7 @@ Get date-related info and format it as you need. Consider the following if today
 ###### Using `intlDates` function
 
 ```
-import { intlDates } from 'useintldates'; // Bring the function into your code as a named export
+import { intlDates } from 'intl-dates'; // Bring the function into your code as a named export
 
 // Retrieve and destructure the 'dates' object from the intlDates function
 const dates = intlDates();
@@ -114,7 +114,7 @@ const dates = intlDates();
 ###### Using `useIntlDates` custom hook
 
 ```
-import useIntlDates from 'useintldates'; // Bring the hook into your component
+import useIntlDates from 'intl-dates'; // Bring the hook into your component
 
 const MyComponent = () => {
 
@@ -141,7 +141,7 @@ Return date information based on a specific date. Consider if you wanted to get 
 ###### Using `intlDates` function
 
 ```
-import { intlDates } from 'useintldates'; // Bring the function into your code as a named export
+import { intlDates } from 'intl-dates'; // Bring the function into your code as a named export
 
 // Retrieve and destructure the 'dates' object from the intlDates function
 const dates = intlDates({
@@ -163,7 +163,7 @@ const dates = intlDates({
 ###### Using `useIntlDates` custom hook
 
 ```
-import useIntlDates from 'useintldates'; // Bring the hook into your component
+import useIntlDates from 'intl-dates'; // Bring the hook into your component
 
 const MyComponent = () => {
 
@@ -194,7 +194,7 @@ Passing in a specific locale through the options object will return the data in 
 ###### Using `intlDates` function
 
 ```
-import { intlDates } from 'useintldates'; // Bring the function into your code as a named export
+import { intlDates } from 'intl-dates'; // Bring the function into your code as a named export
 
 // Retrieve and destructure the 'dates' object from the intlDates function
 const dates = intlDates({
@@ -216,7 +216,7 @@ const dates = intlDates({
 ###### Using `useIntlDates` custom hook
 
 ```
-import useIntlDates from 'useintldates'; // Bring the hook into your component
+import useIntlDates from 'intl-dates'; // Bring the hook into your component
 
 const MyComponent = () => {
 
@@ -248,7 +248,7 @@ The following would make the request with the date for Sunday coming from `dates
 ###### Using `intlDates` function
 
 ```
-import { intlDates } from 'useintldates'; // Bring the function into your code as a named export
+import { intlDates } from 'intl-dates'; // Bring the function into your code as a named export
 
 // Retrieve and destructure the 'dates' object from the intlDates function
 const dates = intlDates();
@@ -264,7 +264,7 @@ fetch(`[urlToYourAPI]/getByDateRange?startDate=${dates.weekStartDate}&endDate=${
 
 ```
     import React, { useEffect } from 'react';
-    import useIntlDates from 'useintldates'; // Bring the hook into your component
+    import useIntlDates from 'intl-dates'; // Bring the hook into your component
 
     const MyComponent = () => {
 

--- a/hook/index.js
+++ b/hook/index.js
@@ -1,13 +1,13 @@
 import { useEffect, useState } from "react";
 
-export default function useIntlDates({ locale = "default" } = {}) {
+export default function useIntlDates({ locale = "default", date = null } = {}) {
   const [intlBaseOptions] = useState({
     weekday: "long",
     day: "numeric",
     month: "numeric",
     year: "numeric",
   });
-  
+
   const [intlMonthWeekdayLongOptions] = useState({
     month: "long",
     weekday: "long",
@@ -72,7 +72,9 @@ export default function useIntlDates({ locale = "default" } = {}) {
   // Set startValues with Intl -- locale must stay English here so switch above can match
   useEffect(() => {
     const formatter = new Intl.DateTimeFormat("en-US", intlBaseOptions);
-    setStartValues(formatter.formatToParts(new Date()));
+    setStartValues(
+      formatter.formatToParts(!!date ? new Date(date) : new Date())
+    );
   }, [intlBaseOptions]);
 
   // Derive this week start and end dates to export
@@ -94,7 +96,7 @@ export default function useIntlDates({ locale = "default" } = {}) {
       });
     }
   }, [startValues]);
-  
+
   // Set base values to export
   useEffect(() => {
     if (startValues) {
@@ -124,7 +126,9 @@ export default function useIntlDates({ locale = "default" } = {}) {
       locale,
       intlMonthWeekdayLongOptions
     );
-    const formatted = formatter.formatToParts(new Date());
+    const formatted = formatter.formatToParts(
+      !!date ? new Date(date) : new Date()
+    );
 
     setDates((prevDates) => {
       return {
@@ -141,7 +145,9 @@ export default function useIntlDates({ locale = "default" } = {}) {
       locale,
       intlMonthWeekdayShortOptions
     );
-    const formatted = formatter.formatToParts(new Date());
+    const formatted = formatter.formatToParts(
+      !!date ? new Date(date) : new Date()
+    );
 
     setDates((prevDates) => {
       return {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "useintldates",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Easily work with dates using the JavaScript Intl methods",
   "main": "index.js",
   "scripts": {

--- a/vanilla/index.js
+++ b/vanilla/index.js
@@ -1,4 +1,4 @@
-export default function intlDates({ locale = "default" } = {}) {
+export default function intlDates({ locale = "default", date = null } = {}) {
   // Set options passed to Intl calls
   const intlBaseOptions = {
     weekday: "long",
@@ -67,7 +67,9 @@ export default function intlDates({ locale = "default" } = {}) {
 
   // Set startValues with Intl -- locale needs to stay English here so switch above can match
   const baseFormatter = new Intl.DateTimeFormat("en-US", intlBaseOptions);
-  const startValues = baseFormatter.formatToParts(new Date());
+  const startValues = baseFormatter.formatToParts(
+    !!date ? new Date(date) : new Date()
+  );
 
   // Derive this week start and end dates to export
   const weekStartDate = `${startValues[6].value}-${
@@ -96,7 +98,9 @@ export default function intlDates({ locale = "default" } = {}) {
     locale,
     intlMonthWeekdayLongOptions
   );
-  const longFormatted = longFormatter.formatToParts(new Date());
+  const longFormatted = longFormatter.formatToParts(
+    !!date ? new Date(date) : new Date()
+  );
 
   const monthLong = longFormatted[0].value;
   const weekdayLong = longFormatted[2].value;
@@ -106,7 +110,9 @@ export default function intlDates({ locale = "default" } = {}) {
     locale,
     intlMonthWeekdayShortOptions
   );
-  const shortFormatted = shortFormatter.formatToParts(new Date());
+  const shortFormatted = shortFormatter.formatToParts(
+    !!date ? new Date(date) : new Date()
+  );
 
   const monthShort = shortFormatted[0].value;
   const weekdayShort = shortFormatted[2].value;


### PR DESCRIPTION
New feature ready - `date` option

With this feature users can pass a date in the options object to get data back based on that specific day instead of only the current day.

Bumped version to `1.2.0` to reflect new feature

Resolves #23 