### PR TITLE
Fix package name from change to `intl-dates`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "useintldates",
+  "name": "intl-dates",
   "version": "1.2.0",
   "description": "Easily work with dates using the JavaScript Intl methods",
   "main": "index.js",
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ZumDeWald/useIntlDates.git"
+    "url": "git+https://github.com/ZumDeWald/intl-dates.git"
   },
   "keywords": [
     "javascript",


### PR DESCRIPTION
Package name did not change over to the new intl-dates.
PR to correct