### PR TITLE
Bug/#25 calculate week

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Both `intlDates` and `useIntlDates` will accept an object of these options ([see
    - default: today's date <br />
    - This option allows you to get back date information based on a specific date. <br />
    - Any value accepted by the JavaScript [Date()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date#Parameters) constructor will work. <br />
-   - Examples: "2020-10-24T14:48:00", "2020-10-24", "10/24/2020", "October 24, 2020"
+   - Examples: "2020-10-24T14:48:00", "10/24/2020", "October 24, 2020"
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@ Easily get useful date-related information using JavaScript Intl.
 
 ### Description
 
-This package provides a quick and easy way to work with dates by returning an object containing commonly used, date-related data. It can also be passed an [options object](#options) to further customize the way the date information comes back. <br />
-
-This package exports both a Vanilla JavaScript function (`intlDates`) and a custom React hook (`useIntlDates`), each of which return an object (`dates`) containing the same key/value pairs.
+This package exports both a Vanilla JavaScript function (`intlDates`) and a custom React hook (`useIntlDates`); each of which return an object (`dates`) containing commonly used, date-related data. Each can also be passed an [options object](#options) to further customize the way the date information comes back. <br />
 
 ### Sections:
 
@@ -29,11 +27,11 @@ This package exports both a Vanilla JavaScript function (`intlDates`) and a cust
 Both the `intlDates` function and `useIntlDates` hook return an object named `dates` with various date-related information allowing you to simply grab it and arrange it as you need. ([see example further down](#examples))<br /> <br />
 The `dates` object returned contains the following key/value pairs:
 
-- `dateDMY`: <br /> &nbsp; String containing the current date in the following format: "DD-MM-YYYY"
+- `dateDMY`: <br /> &nbsp; String containing the date in the following format: "DD-MM-YYYY"
 
-- `dateMDY`: <br /> &nbsp; String containing the current date in the following format: "MM-DD-YYYY"
+- `dateMDY`: <br /> &nbsp; String containing the date in the following format: "MM-DD-YYYY"
 
-- `dateYMD`: <br /> &nbsp; String containing the current date in the following format: "YYYY-MM-DD"
+- `dateYMD`: <br /> &nbsp; String containing the date in the following format: "YYYY-MM-DD"
 
 - `dayOfMonth`: <br /> &nbsp; String containing the day of the month in numeric form, e.g. "24"
 
@@ -43,19 +41,19 @@ The `dates` object returned contains the following key/value pairs:
 
 - `monthShort`: <br /> &nbsp; String containing the month expressed as a short name, e.g. "Oct"
 
-- `weekEndDate`: ([see use case further down](#date-ranges)) <br /> &nbsp; String containing the full date of the Saturday of the current week in the following format: "YYYY-MM-DD"
+- `weekEndDate`: ([see use case further down](#date-ranges)) <br /> &nbsp; String containing the full date of the Saturday of the week in the following format: "YYYY-MM-DD"
 
-- `weekStartDate`: ([see use case further down](#date-ranges)) <br /> &nbsp; String containing the full date of the Sunday of the current week in the following format: "YYYY-MM-DD"
+- `weekStartDate`: ([see use case further down](#date-ranges)) <br /> &nbsp; String containing the full date of the Sunday of the week in the following format: "YYYY-MM-DD"
 
-- `weekdayLong`: <br /> &nbsp; String containing the full name of the current weekday, e.g. "Saturday"
+- `weekdayLong`: <br /> &nbsp; String containing the full name of the weekday, e.g. "Saturday"
 
-- `weekdayShort`: <br /> &nbsp; String containing the short name of the current weekday, e.g. "Sat"
+- `weekdayShort`: <br /> &nbsp; String containing the short name of the weekday, e.g. "Sat"
 
 - `year`: <br /> &nbsp; String containing the year expressed in numeric form, e.g. "2020"
 
 ## Dependencies
 
-Great news! This code uses the power of the [JavaScript Intl object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat). _No outside libraries or code_ is needed by this package, so no alerts that a dependency of a dependency has a security issue!<br />
+This code uses the power of the [JavaScript Intl object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat). _No outside libraries or code_ is needed by this package, so no alerts that a dependency of a dependency has a security issue!<br />
 
 ### There are only 2 things to be aware of if using this package:
 
@@ -187,7 +185,7 @@ const MyComponent = () => {
 
 #### Specify Locale
 
-Passing in a specific locale through the options object will return the data in a specific language. Consider the following if you wanted to be sure the day of the week and month returned in Danish.
+Passing a locale through the options object will return the data in a specific language. Consider the following if you wanted to be sure the day of the week and month returned in Danish.
 
 > Note: the default locale is set to 'default', which allows the browser to choose which locale is used.
 

--- a/hook/index.js
+++ b/hook/index.js
@@ -69,6 +69,37 @@ export default function useIntlDates({ locale = "default", date = null } = {}) {
     }
   };
 
+  const daysInMonth = (monthAsNum) => {
+    switch (monthAsNum) {
+      case 1:
+        return 31;
+      case 2:
+        return 28;
+      case 3:
+        return 31;
+      case 4:
+        return 30;
+      case 5:
+        return 31;
+      case 6:
+        return 30;
+      case 7:
+        return 31;
+      case 8:
+        return 31;
+      case 9:
+        return 30;
+      case 10:
+        return 31;
+      case 11:
+        return 30;
+      case 12:
+        return 31;
+      default:
+        return null;
+    }
+  };
+
   // Set startValues with Intl -- locale must stay English here so switch above can match
   useEffect(() => {
     const formatter = new Intl.DateTimeFormat("en-US", intlBaseOptions);
@@ -80,12 +111,49 @@ export default function useIntlDates({ locale = "default", date = null } = {}) {
   // Derive this week start and end dates to export
   useEffect(() => {
     if (startValues) {
-      let sundayDate = `${startValues[6].value}-${
-        startValues[2].value
-      }-${findStartOfWeek(startValues)}`;
-      let saturdayDate = `${startValues[6].value}-${
-        startValues[2].value
-      }-${findEndOfWeek(startValues)}`;
+      // Week Start Date
+      let sundayDate;
+      const beginOfMonthDiff = findStartOfWeek(startValues);
+
+      if (beginOfMonthDiff <= 0) {
+        let prevYear = null;
+        let prevMonth = Number(startValues[2].value) - 1;
+
+        if (prevMonth === 0) {
+          prevMonth = 12;
+          prevYear = Number(startValues[6].value) - 1;
+        }
+
+        const daysInPrevMonth = daysInMonth(prevMonth);
+
+        sundayDate = `${prevYear || startValues[6].value}-${prevMonth}-${
+          daysInPrevMonth + beginOfMonthDiff
+        }`;
+      } else {
+        sundayDate = `${startValues[6].value}-${startValues[2].value}-${beginOfMonthDiff}`;
+      }
+
+      // Week End Date
+      let saturdayDate;
+      const endOfMonthDiff =
+        findEndOfWeek(startValues) - daysInMonth(Number(startValues[2].value));
+      if (endOfMonthDiff > 0) {
+        let nextYear = null;
+        let nextMonth = Number(startValues[2].value) + 1;
+
+        if (nextMonth === 13) {
+          nextMonth = 1;
+          nextYear = Number(startValues[6].value) + 1;
+        }
+
+        saturdayDate = `${
+          nextYear || startValues[6].value
+        }-${nextMonth}-${endOfMonthDiff}`;
+      } else {
+        saturdayDate = `${startValues[6].value}-${
+          startValues[2].value
+        }-${findEndOfWeek(startValues)}`;
+      }
 
       setDates((prevDates) => {
         return {

--- a/hook/index.js
+++ b/hook/index.js
@@ -106,7 +106,7 @@ export default function useIntlDates({ locale = "default", date = null } = {}) {
     setStartValues(
       formatter.formatToParts(!!date ? new Date(date) : new Date())
     );
-  }, [intlBaseOptions]);
+  }, [intlBaseOptions, date]);
 
   // Derive this week start and end dates to export
   useEffect(() => {
@@ -115,10 +115,12 @@ export default function useIntlDates({ locale = "default", date = null } = {}) {
       let sundayDate;
       const beginOfMonthDiff = findStartOfWeek(startValues);
 
+      // Check if start of week is in previous month
       if (beginOfMonthDiff <= 0) {
         let prevYear = null;
         let prevMonth = Number(startValues[2].value) - 1;
 
+        // Make date adjustments if start of week is in previous year
         if (prevMonth === 0) {
           prevMonth = 12;
           prevYear = Number(startValues[6].value) - 1;
@@ -137,10 +139,13 @@ export default function useIntlDates({ locale = "default", date = null } = {}) {
       let saturdayDate;
       const endOfMonthDiff =
         findEndOfWeek(startValues) - daysInMonth(Number(startValues[2].value));
+
+      // Check if end of week is in next month
       if (endOfMonthDiff > 0) {
         let nextYear = null;
         let nextMonth = Number(startValues[2].value) + 1;
 
+        // Make date adjustments if end of week is in next year
         if (nextMonth === 13) {
           nextMonth = 1;
           nextYear = Number(startValues[6].value) + 1;
@@ -205,7 +210,7 @@ export default function useIntlDates({ locale = "default", date = null } = {}) {
         weekdayLong: formatted[2].value,
       };
     });
-  }, [intlMonthWeekdayLongOptions, locale]);
+  }, [intlMonthWeekdayLongOptions, locale, date]);
 
   // Set monthShort and weekdayShort values to export
   useEffect(() => {
@@ -224,7 +229,7 @@ export default function useIntlDates({ locale = "default", date = null } = {}) {
         weekdayShort: formatted[2].value,
       };
     });
-  }, [intlMonthWeekdayShortOptions, locale]);
+  }, [intlMonthWeekdayShortOptions, locale, date]);
 
   return dates;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "intl-dates",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Easily work with dates using the JavaScript Intl methods",
   "main": "index.js",
   "scripts": {

--- a/vanilla/index.js
+++ b/vanilla/index.js
@@ -110,10 +110,12 @@ export default function intlDates({ locale = "default", date = null } = {}) {
   if (beginOfMonthDiff <= 0) {
     let prevYear = null;
     let prevMonth = Number(startValues[2].value) - 1;
+
     if (prevMonth === 0) {
       prevMonth = 12;
       prevYear = Number(startValues[6].value) - 1;
     }
+
     const daysInPrevMonth = daysInMonth(prevMonth);
 
     weekStartDate = `${prevYear || startValues[6].value}-${prevMonth}-${
@@ -130,6 +132,7 @@ export default function intlDates({ locale = "default", date = null } = {}) {
   if (endOfMonthDiff > 0) {
     let nextYear = null;
     let nextMonth = Number(startValues[2].value) + 1;
+
     if (nextMonth === 13) {
       nextMonth = 1;
       nextYear = Number(startValues[6].value) + 1;

--- a/vanilla/index.js
+++ b/vanilla/index.js
@@ -108,13 +108,15 @@ export default function intlDates({ locale = "default", date = null } = {}) {
   const beginOfMonthDiff = findStartOfWeek(startValues);
 
   if (beginOfMonthDiff <= 0) {
+    let prevYear = null;
     let prevMonth = Number(startValues[2].value) - 1;
     if (prevMonth === 0) {
       prevMonth = 12;
+      prevYear = Number(startValues[6].value) - 1;
     }
     const daysInPrevMonth = daysInMonth(prevMonth);
 
-    weekStartDate = `${startValues[6].value}-${prevMonth}-${
+    weekStartDate = `${prevYear || startValues[6].value}-${prevMonth}-${
       daysInPrevMonth + beginOfMonthDiff
     }`;
   } else {
@@ -126,12 +128,16 @@ export default function intlDates({ locale = "default", date = null } = {}) {
   const endOfMonthDiff =
     findEndOfWeek(startValues) - daysInMonth(Number(startValues[2].value));
   if (endOfMonthDiff > 0) {
+    let nextYear = null;
     let nextMonth = Number(startValues[2].value) + 1;
     if (nextMonth === 13) {
       nextMonth = 1;
+      nextYear = Number(startValues[6].value) + 1;
     }
 
-    weekEndDate = `${startValues[6].value}-${nextMonth}-${endOfMonthDiff}`;
+    weekEndDate = `${
+      nextYear || startValues[6].value
+    }-${nextMonth}-${endOfMonthDiff}`;
   } else {
     weekEndDate = `${startValues[6].value}-${
       startValues[2].value

--- a/vanilla/index.js
+++ b/vanilla/index.js
@@ -65,6 +65,37 @@ export default function intlDates({ locale = "default", date = null } = {}) {
     }
   };
 
+  const daysInMonth = (monthAsNum) => {
+    switch (monthAsNum) {
+      case 1:
+        return 31;
+      case 2:
+        return 28;
+      case 3:
+        return 31;
+      case 4:
+        return 30;
+      case 5:
+        return 31;
+      case 6:
+        return 30;
+      case 7:
+        return 31;
+      case 8:
+        return 31;
+      case 9:
+        return 30;
+      case 10:
+        return 31;
+      case 11:
+        return 30;
+      case 12:
+        return 31;
+      default:
+        return null;
+    }
+  };
+
   // Set startValues with Intl -- locale needs to stay English here so switch above can match
   const baseFormatter = new Intl.DateTimeFormat("en-US", intlBaseOptions);
   const startValues = baseFormatter.formatToParts(

--- a/vanilla/index.js
+++ b/vanilla/index.js
@@ -102,14 +102,41 @@ export default function intlDates({ locale = "default", date = null } = {}) {
     !!date ? new Date(date) : new Date()
   );
 
-  // Derive this week start and end dates to export
-  const weekStartDate = `${startValues[6].value}-${
-    startValues[2].value
-  }-${findStartOfWeek(startValues)}`;
+  /* Derive this week start and end dates to export */
+  // Week Start Date
+  let weekStartDate;
+  const beginOfMonthDiff = findStartOfWeek(startValues);
 
-  const weekEndDate = `${startValues[6].value}-${
-    startValues[2].value
-  }-${findEndOfWeek(startValues)}`;
+  if (beginOfMonthDiff <= 0) {
+    let prevMonth = Number(startValues[2].value) - 1;
+    if (prevMonth === 0) {
+      prevMonth = 12;
+    }
+    const daysInPrevMonth = daysInMonth(prevMonth);
+
+    weekStartDate = `${startValues[6].value}-${prevMonth}-${
+      daysInPrevMonth + beginOfMonthDiff
+    }`;
+  } else {
+    weekStartDate = `${startValues[6].value}-${startValues[2].value}-${beginOfMonthDiff}`;
+  }
+
+  // Week End Date
+  let weekEndDate;
+  const endOfMonthDiff =
+    findEndOfWeek(startValues) - daysInMonth(Number(startValues[2].value));
+  if (endOfMonthDiff > 0) {
+    let nextMonth = Number(startValues[2].value) + 1;
+    if (nextMonth === 13) {
+      nextMonth = 1;
+    }
+
+    weekEndDate = `${startValues[6].value}-${nextMonth}-${endOfMonthDiff}`;
+  } else {
+    weekEndDate = `${startValues[6].value}-${
+      startValues[2].value
+    }-${findEndOfWeek(startValues)}`;
+  }
 
   // Set additional values to export
   const dateYMD = `${startValues[6].value}-${startValues[2].value}-${startValues[4].value}`;

--- a/vanilla/index.js
+++ b/vanilla/index.js
@@ -107,10 +107,12 @@ export default function intlDates({ locale = "default", date = null } = {}) {
   let weekStartDate;
   const beginOfMonthDiff = findStartOfWeek(startValues);
 
+  // Check if start of week is in previous month
   if (beginOfMonthDiff <= 0) {
     let prevYear = null;
     let prevMonth = Number(startValues[2].value) - 1;
 
+    // Make date adjustments if start of week is in previous year
     if (prevMonth === 0) {
       prevMonth = 12;
       prevYear = Number(startValues[6].value) - 1;
@@ -129,10 +131,13 @@ export default function intlDates({ locale = "default", date = null } = {}) {
   let weekEndDate;
   const endOfMonthDiff =
     findEndOfWeek(startValues) - daysInMonth(Number(startValues[2].value));
+
+  // Check if end of week is in next month
   if (endOfMonthDiff > 0) {
     let nextYear = null;
     let nextMonth = Number(startValues[2].value) + 1;
 
+    // Make date adjustments if end of week is in next year
     if (nextMonth === 13) {
       nextMonth = 1;
       nextYear = Number(startValues[6].value) + 1;


### PR DESCRIPTION
This PR fixes a bug caused when the `weekStartDate` or `weekEndDate` fall outside the current month or year.

Specifics:
> Changes made to both Vanilla and Hook versions
- Added switch to return how many days are in any given month
- Added logic to check if `weekStartDate` occurs in previous month and to adjust the month / day if that is the case
- Added additional check to see if the previous month was supposed to be December of the previous year and logic to correctly adjust the month/day/year if so
- Added same type of checks to see if `weekEndDate` occurs in next month/year and if so adjust the day/month/year accordingly
- Minor update to README, mainly removing terminology suggesting the date information was based only on the current day (no longer true since `date` option feature was released)
- Bumped version to 1.2.1 to reflect bug fix / patch

Resolves #25 