### PR TITLE
Enhance/leap year

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # intl-dates
 
-Easily get useful date-related information using JavaScript Intl.
+Easily get useful date-related information in JavaScript (uses Intl).
 
 ### Description
 

--- a/hook/index.js
+++ b/hook/index.js
@@ -19,6 +19,9 @@ export default function useIntlDates({ locale = "default", date = null } = {}) {
   });
 
   const [startValues, setStartValues] = useState();
+  const [startValuesYear, setStartValuesYear] = useState();
+  const [startValuesMonth, setStartValuesMonth] = useState();
+  const [startValuesDayNum, setStartValuesDayNum] = useState();
   const [dates, setDates] = useState({});
 
   const findStartOfWeek = (intlValues) => {
@@ -112,9 +115,13 @@ export default function useIntlDates({ locale = "default", date = null } = {}) {
   // Set startValues with Intl -- locale must stay English here so switch above can match
   useEffect(() => {
     const formatter = new Intl.DateTimeFormat("en-US", intlBaseOptions);
-    setStartValues(
-      formatter.formatToParts(!!date ? new Date(date) : new Date())
+    const startValues = formatter.formatToParts(
+      !!date ? new Date(date) : new Date()
     );
+    setStartValues(startValues);
+    setStartValuesYear(startValues[6].value);
+    setStartValuesMonth(startValues[2].value);
+    setStartValuesDayNum(startValues[4].value);
   }, [intlBaseOptions, date]);
 
   // Derive this week start and end dates to export
@@ -127,50 +134,47 @@ export default function useIntlDates({ locale = "default", date = null } = {}) {
       // Check if start of week is in previous month
       if (beginOfMonthDiff <= 0) {
         let prevYear = null;
-        let prevMonth = Number(startValues[2].value) - 1;
+        let prevMonth = Number(startValuesMonth) - 1;
 
         // Make date adjustments if start of week is in previous year
         if (prevMonth === 0) {
           prevMonth = 12;
-          prevYear = Number(startValues[6].value) - 1;
+          prevYear = Number(startValuesYear) - 1;
         }
 
-        const daysInPrevMonth = daysInMonth(
-          prevMonth,
-          Number(startValues[6].value)
-        );
+        const daysInPrevMonth = daysInMonth(prevMonth, Number(startValuesYear));
 
-        sundayDate = `${prevYear || startValues[6].value}-${prevMonth}-${
+        sundayDate = `${prevYear || startValuesYear}-${prevMonth}-${
           daysInPrevMonth + beginOfMonthDiff
         }`;
       } else {
-        sundayDate = `${startValues[6].value}-${startValues[2].value}-${beginOfMonthDiff}`;
+        sundayDate = `${startValuesYear}-${startValuesMonth}-${beginOfMonthDiff}`;
       }
 
       // Week End Date
       let saturdayDate;
       const endOfMonthDiff =
         findEndOfWeek(startValues) -
-        daysInMonth(Number(startValues[2].value), Number(startValues[6].value));
+        daysInMonth(Number(startValuesMonth), Number(startValuesYear));
 
       // Check if end of week is in next month
       if (endOfMonthDiff > 0) {
         let nextYear = null;
-        let nextMonth = Number(startValues[2].value) + 1;
+        let nextMonth = Number(startValuesMonth) + 1;
 
         // Make date adjustments if end of week is in next year
         if (nextMonth === 13) {
           nextMonth = 1;
-          nextYear = Number(startValues[6].value) + 1;
+          nextYear = Number(startValuesYear) + 1;
         }
 
         saturdayDate = `${
-          nextYear || startValues[6].value
+          nextYear || startValuesYear
         }-${nextMonth}-${endOfMonthDiff}`;
       } else {
-        saturdayDate = `${startValues[6].value}-${
-          startValues[2].value
-        }-${findEndOfWeek(startValues)}`;
+        saturdayDate = `${startValuesYear}-${startValuesMonth}-${findEndOfWeek(
+          startValues
+        )}`;
       }
 
       setDates((prevDates) => {
@@ -186,11 +190,11 @@ export default function useIntlDates({ locale = "default", date = null } = {}) {
   // Set base values to export
   useEffect(() => {
     if (startValues) {
-      let dateYMD = `${startValues[6].value}-${startValues[2].value}-${startValues[4].value}`;
+      let dateYMD = `${startValuesYear}-${startValuesMonth}-${startValuesDayNum}`;
 
-      let dateDMY = `${startValues[4].value}-${startValues[2].value}-${startValues[6].value}`;
+      let dateDMY = `${startValuesDayNum}-${startValuesMonth}-${startValuesYear}`;
 
-      let dateMDY = `${startValues[2].value}-${startValues[4].value}-${startValues[6].value}`;
+      let dateMDY = `${startValuesMonth}-${startValuesDayNum}-${startValuesYear}`;
 
       setDates((prevDates) => {
         return {
@@ -198,9 +202,9 @@ export default function useIntlDates({ locale = "default", date = null } = {}) {
           dateYMD,
           dateDMY,
           dateMDY,
-          monthNumeric: startValues[2].value,
-          dayOfMonth: startValues[4].value,
-          year: startValues[6].value,
+          monthNumeric: startValuesMonth,
+          dayOfMonth: startValuesDayNum,
+          year: startValuesYear,
         };
       });
     }

--- a/hook/index.js
+++ b/hook/index.js
@@ -69,12 +69,21 @@ export default function useIntlDates({ locale = "default", date = null } = {}) {
     }
   };
 
-  const daysInMonth = (monthAsNum) => {
+  const daysInMonth = (monthAsNum, yearAsNum) => {
     switch (monthAsNum) {
       case 1:
         return 31;
       case 2:
-        return 28;
+        // Determine if it is a leap year and adjust Feburary if needed
+        if (yearAsNum % 4 !== 0) {
+          return 28;
+        } else if (yearAsNum % 100 !== 0) {
+          return 29;
+        } else if (yearAsNum % 400 !== 0) {
+          return 28;
+        } else {
+          return 29;
+        }
       case 3:
         return 31;
       case 4:
@@ -126,7 +135,10 @@ export default function useIntlDates({ locale = "default", date = null } = {}) {
           prevYear = Number(startValues[6].value) - 1;
         }
 
-        const daysInPrevMonth = daysInMonth(prevMonth);
+        const daysInPrevMonth = daysInMonth(
+          prevMonth,
+          Number(startValues[6].value)
+        );
 
         sundayDate = `${prevYear || startValues[6].value}-${prevMonth}-${
           daysInPrevMonth + beginOfMonthDiff
@@ -138,7 +150,8 @@ export default function useIntlDates({ locale = "default", date = null } = {}) {
       // Week End Date
       let saturdayDate;
       const endOfMonthDiff =
-        findEndOfWeek(startValues) - daysInMonth(Number(startValues[2].value));
+        findEndOfWeek(startValues) -
+        daysInMonth(Number(startValues[2].value), Number(startValues[6].value));
 
       // Check if end of week is in next month
       if (endOfMonthDiff > 0) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "intl-dates",
-  "version": "1.2.1",
-  "description": "Easily work with dates using the JavaScript Intl methods",
+  "version": "1.2.2",
+  "description": "Easily work with dates in JavaScript (uses Intl)",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/vanilla/index.js
+++ b/vanilla/index.js
@@ -65,12 +65,21 @@ export default function intlDates({ locale = "default", date = null } = {}) {
     }
   };
 
-  const daysInMonth = (monthAsNum) => {
+  const daysInMonth = (monthAsNum, yearAsNum) => {
     switch (monthAsNum) {
       case 1:
         return 31;
       case 2:
-        return 28;
+        // Determine if it is a leap year and adjust Feburary if needed
+        if (yearAsNum % 4 !== 0) {
+          return 28;
+        } else if (yearAsNum % 100 !== 0) {
+          return 29;
+        } else if (yearAsNum % 400 !== 0) {
+          return 28;
+        } else {
+          return 29;
+        }
       case 3:
         return 31;
       case 4:
@@ -118,7 +127,10 @@ export default function intlDates({ locale = "default", date = null } = {}) {
       prevYear = Number(startValues[6].value) - 1;
     }
 
-    const daysInPrevMonth = daysInMonth(prevMonth);
+    const daysInPrevMonth = daysInMonth(
+      prevMonth,
+      Number(startValues[6].value)
+    );
 
     weekStartDate = `${prevYear || startValues[6].value}-${prevMonth}-${
       daysInPrevMonth + beginOfMonthDiff
@@ -130,7 +142,8 @@ export default function intlDates({ locale = "default", date = null } = {}) {
   // Week End Date
   let weekEndDate;
   const endOfMonthDiff =
-    findEndOfWeek(startValues) - daysInMonth(Number(startValues[2].value));
+    findEndOfWeek(startValues) -
+    daysInMonth(Number(startValues[2].value), Number(startValues[6].value));
 
   // Check if end of week is in next month
   if (endOfMonthDiff > 0) {

--- a/vanilla/index.js
+++ b/vanilla/index.js
@@ -111,6 +111,11 @@ export default function intlDates({ locale = "default", date = null } = {}) {
     !!date ? new Date(date) : new Date()
   );
 
+  // Save commonly used values from startValues
+  const startValuesYear = startValues[6].value;
+  const startValuesMonth = startValues[2].value;
+  const startValuesDayNum = startValues[4].value;
+
   /* Derive this week start and end dates to export */
   // Week Start Date
   let weekStartDate;
@@ -119,64 +124,61 @@ export default function intlDates({ locale = "default", date = null } = {}) {
   // Check if start of week is in previous month
   if (beginOfMonthDiff <= 0) {
     let prevYear = null;
-    let prevMonth = Number(startValues[2].value) - 1;
+    let prevMonth = Number(startValuesMonth) - 1;
 
     // Make date adjustments if start of week is in previous year
     if (prevMonth === 0) {
       prevMonth = 12;
-      prevYear = Number(startValues[6].value) - 1;
+      prevYear = Number(startValuesYear) - 1;
     }
 
-    const daysInPrevMonth = daysInMonth(
-      prevMonth,
-      Number(startValues[6].value)
-    );
+    const daysInPrevMonth = daysInMonth(prevMonth, Number(startValuesYear));
 
-    weekStartDate = `${prevYear || startValues[6].value}-${prevMonth}-${
+    weekStartDate = `${prevYear || startValuesYear}-${prevMonth}-${
       daysInPrevMonth + beginOfMonthDiff
     }`;
   } else {
-    weekStartDate = `${startValues[6].value}-${startValues[2].value}-${beginOfMonthDiff}`;
+    weekStartDate = `${startValuesYear}-${startValuesMonth}-${beginOfMonthDiff}`;
   }
 
   // Week End Date
   let weekEndDate;
   const endOfMonthDiff =
     findEndOfWeek(startValues) -
-    daysInMonth(Number(startValues[2].value), Number(startValues[6].value));
+    daysInMonth(Number(startValuesMonth), Number(startValuesYear));
 
   // Check if end of week is in next month
   if (endOfMonthDiff > 0) {
     let nextYear = null;
-    let nextMonth = Number(startValues[2].value) + 1;
+    let nextMonth = Number(startValuesMonth) + 1;
 
     // Make date adjustments if end of week is in next year
     if (nextMonth === 13) {
       nextMonth = 1;
-      nextYear = Number(startValues[6].value) + 1;
+      nextYear = Number(startValuesYear) + 1;
     }
 
     weekEndDate = `${
-      nextYear || startValues[6].value
+      nextYear || startValuesYear
     }-${nextMonth}-${endOfMonthDiff}`;
   } else {
-    weekEndDate = `${startValues[6].value}-${
-      startValues[2].value
-    }-${findEndOfWeek(startValues)}`;
+    weekEndDate = `${startValuesYear}-${startValuesMonth}-${findEndOfWeek(
+      startValues
+    )}`;
   }
 
   // Set additional values to export
-  const dateYMD = `${startValues[6].value}-${startValues[2].value}-${startValues[4].value}`;
+  const dateYMD = `${startValuesYear}-${startValuesMonth}-${startValuesDayNum}`;
 
-  const dateDMY = `${startValues[4].value}-${startValues[2].value}-${startValues[6].value}`;
+  const dateDMY = `${startValuesDayNum}-${startValuesMonth}-${startValuesYear}`;
 
-  const dateMDY = `${startValues[2].value}-${startValues[4].value}-${startValues[6].value}`;
+  const dateMDY = `${startValuesMonth}-${startValuesDayNum}-${startValuesYear}`;
 
-  const monthNumeric = startValues[2].value;
+  const monthNumeric = startValuesMonth;
 
-  const dayOfMonth = startValues[4].value;
+  const dayOfMonth = startValuesDayNum;
 
-  const year = startValues[6].value;
+  const year = startValuesYear;
 
   // Set monthLong weekdayLong values to export
   const longFormatter = new Intl.DateTimeFormat(


### PR DESCRIPTION
This PR adds logic accounting for leap years and has small refactors.

Details:
- Added logic to both vanilla and hook versions changing days in February to 29 if the year being referenced is a leap year.
- Added variables in both vanilla and hook versions to store the year, month, and day(numeric) for use throughout the files as those were used in several places. Storing these values independently should be slightly more efficient than having to look up the value in the original `startValues` array every time they are needed.
- Changed wording in opening of README to clear any confusion that the user of this package will need to know anything about Intl or it's use. The package uses Intl under the hood, but the doc might have hinted that the user would need to work directly with it.
- Bumped version to 1.2.2 to account for these changes.

resolves #35 