### PR TITLE
Bug/safari format

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ This list includes current and planned features. Check the issues page for a mor
 - [x] This package offers a VanillaJS and custom React hook option
 - [x] Options object accepts `locale` property to specify a locale/language for Intl to use
 - [x] Options object will allow a `date` property to get back data based on a specific date instead of only from the current day.
+- [x] Accounts for leap years when getting date information.
 
 ## Why offer VanillaJS and hook options?
 

--- a/hook/index.js
+++ b/hook/index.js
@@ -3,19 +3,18 @@ import { useEffect, useState } from "react";
 export default function useIntlDates({ locale = "default", date = null } = {}) {
   const [intlBaseOptions] = useState({
     weekday: "long",
-    day: "numeric",
     month: "numeric",
+    day: "numeric",
     year: "numeric",
   });
 
   const [intlMonthWeekdayLongOptions] = useState({
     month: "long",
-    weekday: "long",
   });
 
   const [intlMonthWeekdayShortOptions] = useState({
-    month: "short",
     weekday: "short",
+    month: "short",
   });
 
   const [startValues, setStartValues] = useState();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "intl-dates",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Easily work with dates in JavaScript (uses Intl)",
   "main": "index.js",
   "scripts": {

--- a/vanilla/index.js
+++ b/vanilla/index.js
@@ -8,6 +8,7 @@ export default function intlDates({ locale = "default", date = null } = {}) {
   };
 
   const intlMonthLongOptions = {
+    weekday: "long",
     month: "long",
   };
 
@@ -105,7 +106,7 @@ export default function intlDates({ locale = "default", date = null } = {}) {
   ).formatToParts(!!date ? new Date(date) : new Date());
 
   // Loop through Intl return and assign values based on correct type
-  let weekdayLong;
+  let weekdayEng;
   let monthNumeric;
   let dayOfMonth;
   let year;
@@ -115,7 +116,7 @@ export default function intlDates({ locale = "default", date = null } = {}) {
       case "literal":
         break;
       case "weekday":
-        return (weekdayLong = objFromIntlArray.value);
+        return (weekdayEng = objFromIntlArray.value);
       case "month":
         return (monthNumeric = objFromIntlArray.value);
       case "day":
@@ -135,7 +136,7 @@ export default function intlDates({ locale = "default", date = null } = {}) {
 
   // Week Start Date
   let weekStartDate;
-  const beginOfMonthDiff = findStartOfWeek(weekdayLong, Number(dayOfMonth));
+  const beginOfMonthDiff = findStartOfWeek(weekdayEng, Number(dayOfMonth));
 
   // Check if start of week is in previous month
   if (beginOfMonthDiff <= 0) {
@@ -160,7 +161,7 @@ export default function intlDates({ locale = "default", date = null } = {}) {
   // Week End Date
   let weekEndDate;
   const endOfMonthDiff =
-    findEndOfWeek(weekdayLong, Number(dayOfMonth)) -
+    findEndOfWeek(weekdayEng, Number(dayOfMonth)) -
     daysInMonth(Number(monthNumeric), Number(year));
 
   // Check if end of week is in next month
@@ -177,27 +178,43 @@ export default function intlDates({ locale = "default", date = null } = {}) {
     weekEndDate = `${nextYear || year}-${nextMonth}-${endOfMonthDiff}`;
   } else {
     weekEndDate = `${year}-${monthNumeric}-${findEndOfWeek(
-      weekdayLong,
+      weekdayEng,
       Number(dayOfMonth)
     )}`;
   }
 
-  // Set additional values to export
+  // Set year/month/day values to export
   const dateYMD = `${year}-${monthNumeric}-${dayOfMonth}`;
 
   const dateDMY = `${dayOfMonth}-${monthNumeric}-${year}`;
 
   const dateMDY = `${monthNumeric}-${dayOfMonth}-${year}`;
 
-  // Set monthLong values to export
+  // Set weekdayLong monthLong values to export
   const longFormatted = new Intl.DateTimeFormat(
     locale,
     intlMonthLongOptions
   ).formatToParts(!!date ? new Date(date) : new Date());
 
-  const monthLong = longFormatted[0].value;
+  let weekdayLong;
+  let monthLong;
 
-  // Set monthShort and weekdayShort values to export
+  const assignLongValues = (objFromIntlArray) => {
+    switch (objFromIntlArray.type) {
+      case "literal":
+        break;
+      case "weekday":
+        return (weekdayLong = objFromIntlArray.value);
+      case "month":
+        return (monthLong = objFromIntlArray.value);
+    }
+  };
+
+  longFormatted.forEach((item) => {
+    assignLongValues(item);
+  });
+
+  // Set weekdayShort monthShort values to export
   const shortFormatted = new Intl.DateTimeFormat(
     locale,
     intlMonthWeekdayShortOptions

--- a/vanilla/index.js
+++ b/vanilla/index.js
@@ -131,7 +131,8 @@ export default function intlDates({ locale = "default", date = null } = {}) {
     assignInitialValues(item);
   });
 
-  /* Derive this week start and end dates to export */
+  /* === Derive this week start and end dates to export === */
+
   // Week Start Date
   let weekStartDate;
   const beginOfMonthDiff = findStartOfWeek(weekdayLong, Number(dayOfMonth));
@@ -189,10 +190,10 @@ export default function intlDates({ locale = "default", date = null } = {}) {
   const dateMDY = `${monthNumeric}-${dayOfMonth}-${year}`;
 
   // Set monthLong values to export
-  const longFormatter = new Intl.DateTimeFormat(locale, intlMonthLongOptions);
-  const longFormatted = longFormatter.formatToParts(
-    !!date ? new Date(date) : new Date()
-  );
+  const longFormatted = new Intl.DateTimeFormat(
+    locale,
+    intlMonthLongOptions
+  ).formatToParts(!!date ? new Date(date) : new Date());
 
   const monthLong = longFormatted[0].value;
 

--- a/vanilla/index.js
+++ b/vanilla/index.js
@@ -99,10 +99,10 @@ export default function intlDates({ locale = "default", date = null } = {}) {
   };
 
   // Set startValues with Intl -- locale needs to stay English here so switch above can match
-  const baseFormatter = new Intl.DateTimeFormat("en-US", intlBaseOptions);
-  const startValues = baseFormatter.formatToParts(
-    !!date ? new Date(date) : new Date()
-  );
+  const startValues = new Intl.DateTimeFormat(
+    "en-US",
+    intlBaseOptions
+  ).formatToParts(!!date ? new Date(date) : new Date());
 
   // Loop through Intl return and assign values based on correct type
   let weekdayLong;
@@ -122,6 +122,8 @@ export default function intlDates({ locale = "default", date = null } = {}) {
         return (dayOfMonth = objFromIntlArray.value);
       case "year":
         return (year = objFromIntlArray.value);
+      default:
+        break;
     }
   };
 
@@ -173,7 +175,10 @@ export default function intlDates({ locale = "default", date = null } = {}) {
 
     weekEndDate = `${nextYear || year}-${nextMonth}-${endOfMonthDiff}`;
   } else {
-    weekEndDate = `${year}-${monthNumeric}-${findEndOfWeek(startValues)}`;
+    weekEndDate = `${year}-${monthNumeric}-${findEndOfWeek(
+      weekdayLong,
+      Number(dayOfMonth)
+    )}`;
   }
 
   // Set additional values to export
@@ -192,13 +197,10 @@ export default function intlDates({ locale = "default", date = null } = {}) {
   const monthLong = longFormatted[0].value;
 
   // Set monthShort and weekdayShort values to export
-  const shortFormatter = new Intl.DateTimeFormat(
+  const shortFormatted = new Intl.DateTimeFormat(
     locale,
     intlMonthWeekdayShortOptions
-  );
-  const shortFormatted = shortFormatter.formatToParts(
-    !!date ? new Date(date) : new Date()
-  );
+  ).formatToParts(!!date ? new Date(date) : new Date());
 
   let weekdayShort;
   let monthShort;
@@ -208,14 +210,14 @@ export default function intlDates({ locale = "default", date = null } = {}) {
       case "literal":
         break;
       case "weekday":
-        return (weekdayLong = objFromIntlArray.value);
+        return (weekdayShort = objFromIntlArray.value);
       case "month":
-        return (monthNumeric = objFromIntlArray.value);
+        return (monthShort = objFromIntlArray.value);
     }
   };
 
   shortFormatted.forEach((item) => {
-    assignInitialValues(item);
+    assignShortValues(item);
   });
 
   const dates = {

--- a/vanilla/index.js
+++ b/vanilla/index.js
@@ -2,64 +2,57 @@ export default function intlDates({ locale = "default", date = null } = {}) {
   // Set options passed to Intl calls
   const intlBaseOptions = {
     weekday: "long",
-    day: "numeric",
     month: "numeric",
+    day: "numeric",
     year: "numeric",
   };
 
-  const intlMonthWeekdayLongOptions = {
+  const intlMonthLongOptions = {
     month: "long",
-    weekday: "long",
   };
 
   const intlMonthWeekdayShortOptions = {
-    month: "short",
     weekday: "short",
+    month: "short",
   };
 
-  const findStartOfWeek = (intlValues) => {
-    const weekday = intlValues[0].value;
-    const dayOfMonth = intlValues[4].value;
-
+  const findStartOfWeek = (weekday, dayNumeric) => {
     switch (weekday) {
       case "Sunday":
-        return Number(dayOfMonth);
+        return dayNumeric;
       case "Monday":
-        return Number(dayOfMonth) - 1;
+        return dayNumeric - 1;
       case "Tuesday":
-        return Number(dayOfMonth) - 2;
+        return dayNumeric - 2;
       case "Wednesday":
-        return Number(dayOfMonth) - 3;
+        return dayNumeric - 3;
       case "Thursday":
-        return Number(dayOfMonth) - 4;
+        return dayNumeric - 4;
       case "Friday":
-        return Number(dayOfMonth) - 5;
+        return dayNumeric - 5;
       case "Saturday":
-        return Number(dayOfMonth) - 6;
+        return dayNumeric - 6;
       default:
         return null;
     }
   };
 
-  const findEndOfWeek = (intlValues) => {
-    const weekday = intlValues[0].value;
-    const dayOfMonth = intlValues[4].value;
-
+  const findEndOfWeek = (weekday, dayNumeric) => {
     switch (weekday) {
       case "Sunday":
-        return Number(dayOfMonth) + 6;
+        return dayNumeric + 6;
       case "Monday":
-        return Number(dayOfMonth) + 5;
+        return dayNumeric + 5;
       case "Tuesday":
-        return Number(dayOfMonth) + 4;
+        return dayNumeric + 4;
       case "Wednesday":
-        return Number(dayOfMonth) + 3;
+        return dayNumeric + 3;
       case "Thursday":
-        return Number(dayOfMonth) + 2;
+        return dayNumeric + 2;
       case "Friday":
-        return Number(dayOfMonth) + 1;
+        return dayNumeric + 1;
       case "Saturday":
-        return Number(dayOfMonth);
+        return dayNumeric;
       default:
         return null;
     }
@@ -111,86 +104,92 @@ export default function intlDates({ locale = "default", date = null } = {}) {
     !!date ? new Date(date) : new Date()
   );
 
-  // Save commonly used values from startValues
-  const startValuesYear = startValues[6].value;
-  const startValuesMonth = startValues[2].value;
-  const startValuesDayNum = startValues[4].value;
+  // Loop through Intl return and assign values based on correct type
+  let weekdayLong;
+  let monthNumeric;
+  let dayOfMonth;
+  let year;
+
+  const assignInitialValues = (objFromIntlArray) => {
+    switch (objFromIntlArray.type) {
+      case "literal":
+        break;
+      case "weekday":
+        return (weekdayLong = objFromIntlArray.value);
+      case "month":
+        return (monthNumeric = objFromIntlArray.value);
+      case "day":
+        return (dayOfMonth = objFromIntlArray.value);
+      case "year":
+        return (year = objFromIntlArray.value);
+    }
+  };
+
+  startValues.forEach((item) => {
+    assignInitialValues(item);
+  });
 
   /* Derive this week start and end dates to export */
   // Week Start Date
   let weekStartDate;
-  const beginOfMonthDiff = findStartOfWeek(startValues);
+  const beginOfMonthDiff = findStartOfWeek(weekdayLong, Number(dayOfMonth));
 
   // Check if start of week is in previous month
   if (beginOfMonthDiff <= 0) {
     let prevYear = null;
-    let prevMonth = Number(startValuesMonth) - 1;
+    let prevMonth = Number(monthNumeric) - 1;
 
     // Make date adjustments if start of week is in previous year
     if (prevMonth === 0) {
       prevMonth = 12;
-      prevYear = Number(startValuesYear) - 1;
+      prevYear = Number(year) - 1;
     }
 
-    const daysInPrevMonth = daysInMonth(prevMonth, Number(startValuesYear));
+    const daysInPrevMonth = daysInMonth(prevMonth, Number(year));
 
-    weekStartDate = `${prevYear || startValuesYear}-${prevMonth}-${
+    weekStartDate = `${prevYear || year}-${prevMonth}-${
       daysInPrevMonth + beginOfMonthDiff
     }`;
   } else {
-    weekStartDate = `${startValuesYear}-${startValuesMonth}-${beginOfMonthDiff}`;
+    weekStartDate = `${year}-${monthNumeric}-${beginOfMonthDiff}`;
   }
 
   // Week End Date
   let weekEndDate;
   const endOfMonthDiff =
-    findEndOfWeek(startValues) -
-    daysInMonth(Number(startValuesMonth), Number(startValuesYear));
+    findEndOfWeek(weekdayLong, Number(dayOfMonth)) -
+    daysInMonth(Number(monthNumeric), Number(year));
 
   // Check if end of week is in next month
   if (endOfMonthDiff > 0) {
     let nextYear = null;
-    let nextMonth = Number(startValuesMonth) + 1;
+    let nextMonth = Number(monthNumeric) + 1;
 
     // Make date adjustments if end of week is in next year
     if (nextMonth === 13) {
       nextMonth = 1;
-      nextYear = Number(startValuesYear) + 1;
+      nextYear = Number(year) + 1;
     }
 
-    weekEndDate = `${
-      nextYear || startValuesYear
-    }-${nextMonth}-${endOfMonthDiff}`;
+    weekEndDate = `${nextYear || year}-${nextMonth}-${endOfMonthDiff}`;
   } else {
-    weekEndDate = `${startValuesYear}-${startValuesMonth}-${findEndOfWeek(
-      startValues
-    )}`;
+    weekEndDate = `${year}-${monthNumeric}-${findEndOfWeek(startValues)}`;
   }
 
   // Set additional values to export
-  const dateYMD = `${startValuesYear}-${startValuesMonth}-${startValuesDayNum}`;
+  const dateYMD = `${year}-${monthNumeric}-${dayOfMonth}`;
 
-  const dateDMY = `${startValuesDayNum}-${startValuesMonth}-${startValuesYear}`;
+  const dateDMY = `${dayOfMonth}-${monthNumeric}-${year}`;
 
-  const dateMDY = `${startValuesMonth}-${startValuesDayNum}-${startValuesYear}`;
+  const dateMDY = `${monthNumeric}-${dayOfMonth}-${year}`;
 
-  const monthNumeric = startValuesMonth;
-
-  const dayOfMonth = startValuesDayNum;
-
-  const year = startValuesYear;
-
-  // Set monthLong weekdayLong values to export
-  const longFormatter = new Intl.DateTimeFormat(
-    locale,
-    intlMonthWeekdayLongOptions
-  );
+  // Set monthLong values to export
+  const longFormatter = new Intl.DateTimeFormat(locale, intlMonthLongOptions);
   const longFormatted = longFormatter.formatToParts(
     !!date ? new Date(date) : new Date()
   );
 
   const monthLong = longFormatted[0].value;
-  const weekdayLong = longFormatted[2].value;
 
   // Set monthShort and weekdayShort values to export
   const shortFormatter = new Intl.DateTimeFormat(
@@ -201,8 +200,23 @@ export default function intlDates({ locale = "default", date = null } = {}) {
     !!date ? new Date(date) : new Date()
   );
 
-  const monthShort = shortFormatted[0].value;
-  const weekdayShort = shortFormatted[2].value;
+  let weekdayShort;
+  let monthShort;
+
+  const assignShortValues = (objFromIntlArray) => {
+    switch (objFromIntlArray.type) {
+      case "literal":
+        break;
+      case "weekday":
+        return (weekdayLong = objFromIntlArray.value);
+      case "month":
+        return (monthNumeric = objFromIntlArray.value);
+    }
+  };
+
+  shortFormatted.forEach((item) => {
+    assignInitialValues(item);
+  });
 
   const dates = {
     weekStartDate,


### PR DESCRIPTION
This PR corrects a bug found in the discrepancy between Safari and other browsers in the order that `formatToParts` returns data.

Details:
- Added loop / switch to Vanilla and Hook version to go through returned array and correctly assign the values; previously this logic relied on data always being in a specific index of the returned array
- Removed redundant variable setting
- Made `Intl` calls a single line instead of breaking them into pieces
- Tested changes in multiple languages to verify consistency in FireFox / Safari
- Updated version to reflect bug fix

Resolves #38 