### PR TITLE
Bug in hook version

### DIFF
--- a/hook/index.js
+++ b/hook/index.js
@@ -122,9 +122,23 @@ export default function useIntlDates({ locale = "default", date = null } = {}) {
         case "month":
           return setMonthNumeric(objFromIntlArray.value);
         case "day":
-          return setDayOfMonth(objFromIntlArray.value);
+          setDayOfMonth(objFromIntlArray.value);
+          setDates((prevDates) => {
+            return {
+              ...prevDates,
+              dayOfMonth: objFromIntlArray.value,
+            };
+          });
+          break;
         case "year":
-          return setYear(objFromIntlArray.value);
+          setYear(objFromIntlArray.value);
+          setDates((prevDates) => {
+            return {
+              ...prevDates,
+              year: objFromIntlArray.value,
+            };
+          });
+          break;
         default:
           break;
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "intl-dates",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Easily work with dates in JavaScript (uses Intl)",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR clears up a bug found in the hook version of this package. When refactoring during the last update the `dayOfMonth` and `year` values were omitted from the final dates object.
The Vanilla version was exporting all values as expected.

Details:
- Added `dayOfMonth` and `year` values back into the final dates object exported by `useIntlDates` hook 
- Bumped version to 1.2.4 to reflect bug fix
Closes #41 