### PR TITLE
Startofweek

### DIFF
--- a/hook/index.js
+++ b/hook/index.js
@@ -1,6 +1,13 @@
 import { useEffect, useState } from "react";
 
-export default function useIntlDates({ locale = "default", date = null } = {}) {
+export default function useIntlDates({
+  locale = "default",
+  date = null,
+  weekStartsOn = "SUN",
+} = {}) {
+  // Ensure weekStartsOn is 3 letters all caps
+  weekStartsOn = weekStartsOn.substr(0, 2).toUpperCase();
+
   const [intlBaseOptions] = useState({
     weekday: "long",
     month: "numeric",
@@ -27,19 +34,19 @@ export default function useIntlDates({ locale = "default", date = null } = {}) {
   const findStartOfWeek = (weekday, dayNumeric) => {
     switch (weekday) {
       case "Sunday":
-        return dayNumeric;
+        return weekStartsOn === "MON" ? dayNumeric - 6 : dayNumeric;
       case "Monday":
-        return dayNumeric - 1;
+        return weekStartsOn === "MON" ? dayNumeric : dayNumeric - 1;
       case "Tuesday":
-        return dayNumeric - 2;
+        return weekStartsOn === "MON" ? dayNumeric - 1 : dayNumeric - 2;
       case "Wednesday":
-        return dayNumeric - 3;
+        return weekStartsOn === "MON" ? dayNumeric - 2 : dayNumeric - 3;
       case "Thursday":
-        return dayNumeric - 4;
+        return weekStartsOn === "MON" ? dayNumeric - 3 : dayNumeric - 4;
       case "Friday":
-        return dayNumeric - 5;
+        return weekStartsOn === "MON" ? dayNumeric - 4 : dayNumeric - 5;
       case "Saturday":
-        return dayNumeric - 6;
+        return weekStartsOn === "MON" ? dayNumeric - 5 : dayNumeric - 6;
       default:
         return null;
     }
@@ -48,19 +55,19 @@ export default function useIntlDates({ locale = "default", date = null } = {}) {
   const findEndOfWeek = (weekday, dayNumeric) => {
     switch (weekday) {
       case "Sunday":
-        return dayNumeric + 6;
+        return weekStartsOn === "MON" ? dayNumeric : dayNumeric + 6;
       case "Monday":
-        return dayNumeric + 5;
+        return weekStartsOn === "MON" ? dayNumeric + 6 : dayNumeric + 5;
       case "Tuesday":
-        return dayNumeric + 4;
+        return weekStartsOn === "MON" ? dayNumeric + 5 : dayNumeric + 4;
       case "Wednesday":
-        return dayNumeric + 3;
+        return weekStartsOn === "MON" ? dayNumeric + 4 : dayNumeric + 3;
       case "Thursday":
-        return dayNumeric + 2;
+        return weekStartsOn === "MON" ? dayNumeric + 3 : dayNumeric + 2;
       case "Friday":
-        return dayNumeric + 1;
+        return weekStartsOn === "MON" ? dayNumeric + 2 : dayNumeric + 1;
       case "Saturday":
-        return dayNumeric;
+        return weekStartsOn === "MON" ? dayNumeric + 1 : dayNumeric;
       default:
         return null;
     }

--- a/hook/index.js
+++ b/hook/index.js
@@ -120,29 +120,29 @@ export default function useIntlDates({
       intlBaseOptions
     ).formatToParts(!!date ? new Date(date) : new Date());
 
-    const assignInitialValues = (objFromIntlArray) => {
-      switch (objFromIntlArray.type) {
+    const assignInitialValues = (intlObj) => {
+      switch (intlObj.type) {
         case "literal":
           break;
         case "weekday":
-          return setWeekdayEng(objFromIntlArray.value);
+          return setWeekdayEng(intlObj.value);
         case "month":
-          return setMonthNumeric(objFromIntlArray.value);
+          return setMonthNumeric(intlObj.value);
         case "day":
-          setDayOfMonth(objFromIntlArray.value);
+          setDayOfMonth(intlObj.value);
           setDates((prevDates) => {
             return {
               ...prevDates,
-              dayOfMonth: objFromIntlArray.value,
+              dayOfMonth: intlObj.value,
             };
           });
           break;
         case "year":
-          setYear(objFromIntlArray.value);
+          setYear(intlObj.value);
           setDates((prevDates) => {
             return {
               ...prevDates,
-              year: objFromIntlArray.value,
+              year: intlObj.value,
             };
           });
           break;
@@ -248,21 +248,13 @@ export default function useIntlDates({
     let weekdayLong;
     let monthLong;
 
-    const assignLongValues = (objFromIntlArray) => {
-      switch (objFromIntlArray.type) {
-        case "literal":
-          break;
-        case "weekday":
-          return (weekdayLong = objFromIntlArray.value);
-        case "month":
-          return (monthLong = objFromIntlArray.value);
-        default:
-          break;
+    formatted.forEach((intlObj) => {
+      if (intlObj.type === "weekday") {
+        weekdayLong = intlObj.value;
       }
-    };
-
-    formatted.forEach((item) => {
-      assignLongValues(item);
+      if (intlObj.type === "month") {
+        monthLong = intlObj.value;
+      }
     });
 
     setDates((prevDates) => {
@@ -284,21 +276,13 @@ export default function useIntlDates({
     let weekdayShort;
     let monthShort;
 
-    const assignShortValues = (objFromIntlArray) => {
-      switch (objFromIntlArray.type) {
-        case "literal":
-          break;
-        case "weekday":
-          return (weekdayShort = objFromIntlArray.value);
-        case "month":
-          return (monthShort = objFromIntlArray.value);
-        default:
-          break;
+    formatted.forEach((intlObj) => {
+      if (intlObj.type === "weekday") {
+        weekdayShort = intlObj.value;
       }
-    };
-
-    formatted.forEach((item) => {
-      assignShortValues(item);
+      if (intlObj.type === "month") {
+        monthShort = intlObj.value;
+      }
     });
 
     setDates((prevDates) => {

--- a/hook/index.js
+++ b/hook/index.js
@@ -6,7 +6,7 @@ export default function useIntlDates({
   weekStartsOn = "SUN",
 } = {}) {
   // Ensure weekStartsOn is 3 letters all caps
-  weekStartsOn = weekStartsOn.substr(0, 2).toUpperCase();
+  weekStartsOn = weekStartsOn.substr(0, 3).toUpperCase();
 
   const [intlBaseOptions] = useState({
     weekday: "long",
@@ -73,44 +73,32 @@ export default function useIntlDates({
     }
   };
 
-  const daysInMonth = (monthAsNum, yearAsNum) => {
-    switch (monthAsNum) {
-      case 1:
-        return 31;
-      case 2:
-        // Determine if it is a leap year and adjust Feburary if needed
-        if (yearAsNum % 4 !== 0) {
-          return 28;
-        } else if (yearAsNum % 100 !== 0) {
-          return 29;
-        } else if (yearAsNum % 400 !== 0) {
-          return 28;
-        } else {
-          return 29;
-        }
-      case 3:
-        return 31;
-      case 4:
-        return 30;
-      case 5:
-        return 31;
-      case 6:
-        return 30;
-      case 7:
-        return 31;
-      case 8:
-        return 31;
-      case 9:
-        return 30;
-      case 10:
-        return 31;
-      case 11:
-        return 30;
-      case 12:
-        return 31;
-      default:
-        return null;
+  const leapYearCheck = (yearAsNum) => {
+    // Determine if it is a leap year and adjust Feburary if needed
+    if (yearAsNum % 4 !== 0) {
+      return 28;
+    } else if (yearAsNum % 100 !== 0) {
+      return 29;
+    } else if (yearAsNum % 400 !== 0) {
+      return 28;
+    } else {
+      return 29;
     }
+  };
+
+  const daysInMonth = {
+    1: 31,
+    2: leapYearCheck(Number(year)),
+    3: 31,
+    4: 30,
+    5: 31,
+    6: 30,
+    7: 31,
+    8: 31,
+    9: 30,
+    10: 31,
+    11: 30,
+    12: 31,
   };
 
   // Set startValues with Intl -- locale must stay English here so switch above can match
@@ -174,7 +162,7 @@ export default function useIntlDates({
           prevYear = Number(year) - 1;
         }
 
-        const daysInPrevMonth = daysInMonth(prevMonth, Number(year));
+        const daysInPrevMonth = daysInMonth[prevMonth];
 
         weekStartDate = `${prevYear || year}-${prevMonth}-${
           daysInPrevMonth + beginOfMonthDiff
@@ -187,7 +175,7 @@ export default function useIntlDates({
       let weekEndDate;
       const endOfMonthDiff =
         findEndOfWeek(weekdayEng, Number(dayOfMonth)) -
-        daysInMonth(Number(monthNumeric), Number(year));
+        daysInMonth[monthNumeric];
 
       // Check if end of week is in next month
       if (endOfMonthDiff > 0) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "intl-dates",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Easily work with dates in JavaScript (uses Intl)",
   "main": "index.js",
   "scripts": {

--- a/vanilla/index.js
+++ b/vanilla/index.js
@@ -118,18 +118,18 @@ export default function intlDates({
   let dayOfMonth;
   let year;
 
-  const assignInitialValues = (objFromIntlArray) => {
-    switch (objFromIntlArray.type) {
+  const assignInitialValues = (intlObj) => {
+    switch (intlObj.type) {
       case "literal":
         break;
       case "weekday":
-        return (weekdayEng = objFromIntlArray.value);
+        return (weekdayEng = intlObj.value);
       case "month":
-        return (monthNumeric = objFromIntlArray.value);
+        return (monthNumeric = intlObj.value);
       case "day":
-        return (dayOfMonth = objFromIntlArray.value);
+        return (dayOfMonth = intlObj.value);
       case "year":
-        return (year = objFromIntlArray.value);
+        return (year = intlObj.value);
       default:
         break;
     }
@@ -206,19 +206,13 @@ export default function intlDates({
   let weekdayLong;
   let monthLong;
 
-  const assignLongValues = (objFromIntlArray) => {
-    switch (objFromIntlArray.type) {
-      case "literal":
-        break;
-      case "weekday":
-        return (weekdayLong = objFromIntlArray.value);
-      case "month":
-        return (monthLong = objFromIntlArray.value);
+  longFormatted.forEach((intlObj) => {
+    if (intlObj.type === "weekday") {
+      weekdayLong = intlObj.value;
     }
-  };
-
-  longFormatted.forEach((item) => {
-    assignLongValues(item);
+    if (intlObj.type === "month") {
+      monthLong = intlObj.value;
+    }
   });
 
   // Set weekdayShort monthShort values to export
@@ -230,19 +224,13 @@ export default function intlDates({
   let weekdayShort;
   let monthShort;
 
-  const assignShortValues = (objFromIntlArray) => {
-    switch (objFromIntlArray.type) {
-      case "literal":
-        break;
-      case "weekday":
-        return (weekdayShort = objFromIntlArray.value);
-      case "month":
-        return (monthShort = objFromIntlArray.value);
+  shortFormatted.forEach((intlObj) => {
+    if (intlObj.type === "weekday") {
+      weekdayShort = intlObj.value;
     }
-  };
-
-  shortFormatted.forEach((item) => {
-    assignShortValues(item);
+    if (intlObj.type === "month") {
+      monthShort = intlObj.value;
+    }
   });
 
   const dates = {

--- a/vanilla/index.js
+++ b/vanilla/index.js
@@ -1,4 +1,11 @@
-export default function intlDates({ locale = "default", date = null } = {}) {
+export default function intlDates({
+  locale = "default",
+  date = null,
+  weekStartsOn = "SUN",
+} = {}) {
+  // Ensure weekStartsOn is 3 letters all caps
+  weekStartsOn = weekStartsOn.substr(0, 2).toUpperCase();
+
   // Set options passed to Intl calls
   const intlBaseOptions = {
     weekday: "long",
@@ -20,19 +27,19 @@ export default function intlDates({ locale = "default", date = null } = {}) {
   const findStartOfWeek = (weekday, dayNumeric) => {
     switch (weekday) {
       case "Sunday":
-        return dayNumeric;
+        return weekStartsOn === "MON" ? dayNumeric - 6 : dayNumeric;
       case "Monday":
-        return dayNumeric - 1;
+        return weekStartsOn === "MON" ? dayNumeric : dayNumeric - 1;
       case "Tuesday":
-        return dayNumeric - 2;
+        return weekStartsOn === "MON" ? dayNumeric - 1 : dayNumeric - 2;
       case "Wednesday":
-        return dayNumeric - 3;
+        return weekStartsOn === "MON" ? dayNumeric - 2 : dayNumeric - 3;
       case "Thursday":
-        return dayNumeric - 4;
+        return weekStartsOn === "MON" ? dayNumeric - 3 : dayNumeric - 4;
       case "Friday":
-        return dayNumeric - 5;
+        return weekStartsOn === "MON" ? dayNumeric - 4 : dayNumeric - 5;
       case "Saturday":
-        return dayNumeric - 6;
+        return weekStartsOn === "MON" ? dayNumeric - 5 : dayNumeric - 6;
       default:
         return null;
     }
@@ -41,19 +48,19 @@ export default function intlDates({ locale = "default", date = null } = {}) {
   const findEndOfWeek = (weekday, dayNumeric) => {
     switch (weekday) {
       case "Sunday":
-        return dayNumeric + 6;
+        return weekStartsOn === "MON" ? dayNumeric : dayNumeric + 6;
       case "Monday":
-        return dayNumeric + 5;
+        return weekStartsOn === "MON" ? dayNumeric + 6 : dayNumeric + 5;
       case "Tuesday":
-        return dayNumeric + 4;
+        return weekStartsOn === "MON" ? dayNumeric + 5 : dayNumeric + 4;
       case "Wednesday":
-        return dayNumeric + 3;
+        return weekStartsOn === "MON" ? dayNumeric + 4 : dayNumeric + 3;
       case "Thursday":
-        return dayNumeric + 2;
+        return weekStartsOn === "MON" ? dayNumeric + 3 : dayNumeric + 2;
       case "Friday":
-        return dayNumeric + 1;
+        return weekStartsOn === "MON" ? dayNumeric + 2 : dayNumeric + 1;
       case "Saturday":
-        return dayNumeric;
+        return weekStartsOn === "MON" ? dayNumeric + 1 : dayNumeric;
       default:
         return null;
     }

--- a/vanilla/index.js
+++ b/vanilla/index.js
@@ -4,7 +4,7 @@ export default function intlDates({
   weekStartsOn = "SUN",
 } = {}) {
   // Ensure weekStartsOn is 3 letters all caps
-  weekStartsOn = weekStartsOn.substr(0, 2).toUpperCase();
+  weekStartsOn = weekStartsOn.substr(0, 3).toUpperCase();
 
   // Set options passed to Intl calls
   const intlBaseOptions = {

--- a/vanilla/index.js
+++ b/vanilla/index.js
@@ -66,46 +66,6 @@ export default function intlDates({
     }
   };
 
-  const daysInMonth = (monthAsNum, yearAsNum) => {
-    switch (monthAsNum) {
-      case 1:
-        return 31;
-      case 2:
-        // Determine if it is a leap year and adjust Feburary if needed
-        if (yearAsNum % 4 !== 0) {
-          return 28;
-        } else if (yearAsNum % 100 !== 0) {
-          return 29;
-        } else if (yearAsNum % 400 !== 0) {
-          return 28;
-        } else {
-          return 29;
-        }
-      case 3:
-        return 31;
-      case 4:
-        return 30;
-      case 5:
-        return 31;
-      case 6:
-        return 30;
-      case 7:
-        return 31;
-      case 8:
-        return 31;
-      case 9:
-        return 30;
-      case 10:
-        return 31;
-      case 11:
-        return 30;
-      case 12:
-        return 31;
-      default:
-        return null;
-    }
-  };
-
   // Set startValues with Intl -- locale needs to stay English here so switch above can match
   const startValues = new Intl.DateTimeFormat(
     "en-US",
@@ -139,6 +99,34 @@ export default function intlDates({
     assignInitialValues(item);
   });
 
+  const leapYearCheck = (yearAsNum) => {
+    // Determine if it is a leap year and adjust Feburary if needed
+    if (yearAsNum % 4 !== 0) {
+      return 28;
+    } else if (yearAsNum % 100 !== 0) {
+      return 29;
+    } else if (yearAsNum % 400 !== 0) {
+      return 28;
+    } else {
+      return 29;
+    }
+  };
+
+  const daysInMonth = {
+    1: 31,
+    2: leapYearCheck(Number(year)),
+    3: 31,
+    4: 30,
+    5: 31,
+    6: 30,
+    7: 31,
+    8: 31,
+    9: 30,
+    10: 31,
+    11: 30,
+    12: 31,
+  };
+
   /* === Derive this week start and end dates to export === */
 
   // Week Start Date
@@ -156,7 +144,7 @@ export default function intlDates({
       prevYear = Number(year) - 1;
     }
 
-    const daysInPrevMonth = daysInMonth(prevMonth, Number(year));
+    const daysInPrevMonth = daysInMonth[prevMonth];
 
     weekStartDate = `${prevYear || year}-${prevMonth}-${
       daysInPrevMonth + beginOfMonthDiff
@@ -168,8 +156,7 @@ export default function intlDates({
   // Week End Date
   let weekEndDate;
   const endOfMonthDiff =
-    findEndOfWeek(weekdayEng, Number(dayOfMonth)) -
-    daysInMonth(Number(monthNumeric), Number(year));
+    findEndOfWeek(weekdayEng, Number(dayOfMonth)) - daysInMonth[monthNumeric];
 
   // Check if end of week is in next month
   if (endOfMonthDiff > 0) {


### PR DESCRIPTION
This PR add the ability to pass `weekStartsOn` property to options and set it to `"MON"` or any version of the string "Monday" in order to have the returning start and end of week days be based on Monday being the start of the week (instead of the default Sunday).

There are also some minor refactors and house cleaning items.

Details:
- Added logic to check for and handle `weekStartsOn` property if passed in options object
- Added to hook and vanilla, tested with both
- Refactored a few of the switch statements into objects (daysInMonth and a few setting functions). This makes the package slightly simpler/cleaner

Closes #44 